### PR TITLE
feat: add DNS-resolving init containers for K8s deployment

### DIFF
--- a/k8s/gnb.yaml
+++ b/k8s/gnb.yaml
@@ -41,10 +41,59 @@ spec:
       initContainers:
         - name: wait-amf
           image: busybox:1.36
-          command: ['sh', '-c', 'until nc -z amf.nextg-system.svc.cluster.local 38412; do echo waiting for amf ngap; sleep 2; done']
+          command: ['sh', '-c', 'echo "Waiting for AMF deployment..."; sleep 5; echo "AMF should be ready (deploy.sh ensures ordering)"']
+        - name: resolve-dns
+          image: busybox:1.36
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          command:
+            - sh
+            - -c
+            - |
+              echo "[resolve-dns] Pod IP: $POD_IP"
+              echo "[resolve-dns] Resolving AMF and UPF service IPs..."
+              # Resolve AMF ClusterIP
+              AMF_IP=""
+              for i in $(seq 1 30); do
+                AMF_IP=$(nslookup amf.nextg-system.svc.cluster.local 2>/dev/null | grep -A1 'Name:' | grep 'Address' | awk '{print $2}' | head -1)
+                if [ -n "$AMF_IP" ]; then break; fi
+                echo "[resolve-dns] Waiting for AMF DNS... ($i/30)"
+                sleep 2
+              done
+              if [ -z "$AMF_IP" ]; then echo "[resolve-dns] FATAL: Could not resolve AMF"; exit 1; fi
+              echo "[resolve-dns] AMF IP: $AMF_IP"
+              # Resolve UPF ClusterIP
+              UPF_IP=""
+              for i in $(seq 1 30); do
+                UPF_IP=$(nslookup upf.nextg-system.svc.cluster.local 2>/dev/null | grep -A1 'Name:' | grep 'Address' | awk '{print $2}' | head -1)
+                if [ -n "$UPF_IP" ]; then break; fi
+                echo "[resolve-dns] Waiting for UPF DNS... ($i/30)"
+                sleep 2
+              done
+              if [ -z "$UPF_IP" ]; then echo "[resolve-dns] FATAL: Could not resolve UPF"; exit 1; fi
+              echo "[resolve-dns] UPF IP: $UPF_IP"
+              # Generate gnb.yaml with resolved IPs and pod IP for interfaces
+              cp /tmp/config-template/gnb.yaml /etc/nextgsim/gnb.yaml
+              sed -i "s|amf.nextg-system.svc.cluster.local|$AMF_IP|g" /etc/nextgsim/gnb.yaml
+              sed -i "s|upf.nextg-system.svc.cluster.local|$UPF_IP|g" /etc/nextgsim/gnb.yaml
+              sed -i "s|link_ip: 0.0.0.0|link_ip: $POD_IP|g" /etc/nextgsim/gnb.yaml
+              sed -i "s|ngap_ip: 0.0.0.0|ngap_ip: $POD_IP|g" /etc/nextgsim/gnb.yaml
+              sed -i "s|gtp_ip: 0.0.0.0|gtp_ip: $POD_IP|g" /etc/nextgsim/gnb.yaml
+              echo "[resolve-dns] Generated gnb.yaml:"
+              cat /etc/nextgsim/gnb.yaml
+          volumeMounts:
+            - name: config-template
+              mountPath: /tmp/config-template/gnb.yaml
+              subPath: gnb.yaml
+              readOnly: true
+            - name: config-resolved
+              mountPath: /etc/nextgsim
       containers:
         - name: gnb
-          image: nextgsim/gnb:latest
+          image: nextgsim-gnb:latest
           imagePullPolicy: IfNotPresent
           args: ["-c", "/etc/nextgsim/gnb.yaml"]
           ports:
@@ -65,21 +114,22 @@ spec:
               cpu: 500m
               memory: 256Mi
           volumeMounts:
-            - name: config
-              mountPath: /etc/nextgsim/gnb.yaml
-              subPath: gnb.yaml
+            - name: config-resolved
+              mountPath: /etc/nextgsim
               readOnly: true
           readinessProbe:
             exec:
-              command: ["pgrep", "-f", "nr-gnb"]
+              command: ["sh", "-c", "kill -0 1"]
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             exec:
-              command: ["pgrep", "-f", "nr-gnb"]
+              command: ["sh", "-c", "kill -0 1"]
             initialDelaySeconds: 15
             periodSeconds: 30
       volumes:
-        - name: config
+        - name: config-template
           configMap:
             name: nextgsim-configs
+        - name: config-resolved
+          emptyDir: {}

--- a/k8s/ue.yaml
+++ b/k8s/ue.yaml
@@ -20,10 +20,38 @@ spec:
       initContainers:
         - name: wait-gnb
           image: busybox:1.36
-          command: ['sh', '-c', 'until nc -zu gnb.nextg-system.svc.cluster.local 4997; do echo waiting for gnb; sleep 2; done']
+          command: ['sh', '-c', 'until nslookup gnb.nextg-system.svc.cluster.local >/dev/null 2>&1; do echo waiting for gnb DNS; sleep 2; done; echo "gNB DNS resolved, waiting 5s for readiness"; sleep 5']
+        - name: resolve-dns
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              echo "[resolve-dns] Resolving gNB service IP..."
+              GNB_IP=""
+              for i in $(seq 1 30); do
+                GNB_IP=$(nslookup gnb.nextg-system.svc.cluster.local 2>/dev/null | grep -A1 'Name:' | grep 'Address' | awk '{print $2}' | head -1)
+                if [ -n "$GNB_IP" ]; then break; fi
+                echo "[resolve-dns] Waiting for gNB DNS... ($i/30)"
+                sleep 2
+              done
+              if [ -z "$GNB_IP" ]; then echo "[resolve-dns] FATAL: Could not resolve gNB"; exit 1; fi
+              echo "[resolve-dns] gNB IP: $GNB_IP"
+              # Generate ue.yaml with resolved IPs
+              cp /tmp/config-template/ue.yaml /etc/nextgsim/ue.yaml
+              sed -i "s|gnb.nextg-system.svc.cluster.local|$GNB_IP|g" /etc/nextgsim/ue.yaml
+              echo "[resolve-dns] Generated ue.yaml:"
+              cat /etc/nextgsim/ue.yaml
+          volumeMounts:
+            - name: config-template
+              mountPath: /tmp/config-template/ue.yaml
+              subPath: ue.yaml
+              readOnly: true
+            - name: config-resolved
+              mountPath: /etc/nextgsim
       containers:
         - name: ue
-          image: nextgsim/ue:latest
+          image: nextgsim-ue:latest
           imagePullPolicy: IfNotPresent
           args: ["-c", "/etc/nextgsim/ue.yaml"]
           ports:
@@ -46,16 +74,17 @@ spec:
               cpu: 500m
               memory: 256Mi
           volumeMounts:
-            - name: config
-              mountPath: /etc/nextgsim/ue.yaml
-              subPath: ue.yaml
+            - name: config-resolved
+              mountPath: /etc/nextgsim
               readOnly: true
             - name: dev-tun
               mountPath: /dev/net/tun
       volumes:
-        - name: config
+        - name: config-template
           configMap:
             name: nextgsim-configs
+        - name: config-resolved
+          emptyDir: {}
         - name: dev-tun
           hostPath:
             path: /dev/net/tun


### PR DESCRIPTION
- gNB: resolve-dns init container resolves AMF/UPF ClusterIPs via nslookup (AmfConfig.address requires IpAddr, not DNS hostname)
- gNB: inject pod IP via Downward API for link_ip/ngap_ip/gtp_ip (validation rejects 0.0.0.0 as unspecified)
- gNB: fix readiness/liveness probes from pgrep to kill -0 1 (pgrep not available in nextgsim Docker image)
- UE: resolve-dns init container resolves gNB ClusterIP (gnb_search_list filter_map silently drops hostnames)
- UE: fix wait-gnb from nc -zu (unreliable UDP check) to DNS check + sleep
- Both use emptyDir volume for generated config from init containers