### PR TITLE
feat(ue): reuse stored SUCI while T3519 runs (#52)

### DIFF
--- a/nextgsim-ue/src/main.rs
+++ b/nextgsim-ue/src/main.rs
@@ -1845,13 +1845,22 @@ async fn handle_unmanaged_mm_message(
                 Ok(id_req) => {
                     info!("Identity Request - Type: {:?}", id_req.identity_type.value);
 
-                    // Build a fresh SUCI for the Identity Response (fresh
-                    // ephemeral key per concealment for the ECIES profiles)
-                    let suci_data = match build_suci_from_config(&task_base.config) {
-                        Ok(suci_data) => suci_data,
-                        Err(e) => {
-                            warn!("Cannot answer Identity Request: SUCI build failed: {e}");
-                            return;
+                    // TS 24.501 §5.4.3.3 b): reuse the stored SUCI while T3519 is
+                    // running; otherwise build a fresh one, store it and arm
+                    // T3519 so the frequency limit (TS 33.501 §6.12.4) applies.
+                    let suci_data = if let Some(stored) = orch.stored_suci_while_t3519_running() {
+                        debug!("Reusing stored SUCI for Identity Response (T3519 running)");
+                        stored
+                    } else {
+                        match build_suci_from_config(&task_base.config) {
+                            Ok(fresh) => {
+                                orch.store_suci_and_arm_t3519(fresh.clone());
+                                fresh
+                            }
+                            Err(e) => {
+                                warn!("Cannot answer Identity Request: SUCI build failed: {e}");
+                                return;
+                            }
                         }
                     };
                     let mobile_identity =

--- a/nextgsim-ue/src/nas/mm/orchestrator.rs
+++ b/nextgsim-ue/src/nas/mm/orchestrator.rs
@@ -51,7 +51,8 @@ use nextgsim_nas::security::{
 
 use crate::timer::{
     GprsTimer2, GprsTimer3, NasTimerManager, TimerExpiryEvent, TIMER_T3346, TIMER_T3502,
-    TIMER_T3510, TIMER_T3511, TIMER_T3512, TIMER_T3516, TIMER_T3517, TIMER_T3520, TIMER_T3521,
+    TIMER_T3510, TIMER_T3511, TIMER_T3512, TIMER_T3516, TIMER_T3517, TIMER_T3519, TIMER_T3520,
+    TIMER_T3521,
 };
 
 use super::state::{CmState, MmStateMachine, MmSubState, UpdateStatus};
@@ -424,6 +425,12 @@ pub struct MmOrchestrator {
     // -- deregistration state --
     dereg_pdu: Option<Vec<u8>>,
 
+    // -- SUCI freshness (TS 24.501 §5.4.3.3 / §5.5.1.2.2) --
+    /// The last SUCI sent to the network. Reused while T3519 is running instead
+    /// of generating a fresh ECIES concealment on every IDENTITY/REGISTRATION
+    /// request (TS 33.501 §6.12.4 frequency limit).
+    stored_suci: Option<Vec<u8>>,
+
     // -- UE policy delivery service (UPDP, TS 24.501 Annex D) --
     /// UE policy sections stored by `(PLMN, UPSC)` (TS 24.501 D.2.1.3 / D.3).
     ue_policy_sections: HashMap<(PlmnId, u16), StoredUePolicySection>,
@@ -458,8 +465,29 @@ impl MmOrchestrator {
             usim_invalid: false,
             n1_mode_disabled: false,
             dereg_pdu: None,
+            stored_suci: None,
             ue_policy_sections: HashMap::new(),
         }
+    }
+
+    /// TS 24.501 §5.4.3.3 b): while T3519 is running the UE must reuse the SUCI
+    /// it last sent instead of generating a fresh concealment. Returns the
+    /// stored SUCI to reuse, or `None` when the caller must generate (and then
+    /// store, via [`Self::store_suci_and_arm_t3519`]) a fresh one.
+    pub fn stored_suci_while_t3519_running(&self) -> Option<Vec<u8>> {
+        if self.timers.is_running(TIMER_T3519) == Some(true) {
+            self.stored_suci.clone()
+        } else {
+            None
+        }
+    }
+
+    /// Store a freshly generated SUCI and arm T3519 so subsequent
+    /// IDENTITY/REGISTRATION requests reuse it until the timer expires
+    /// (TS 24.501 §5.4.3.3 / §5.5.1.2.2, TS 33.501 §6.12.4).
+    pub fn store_suci_and_arm_t3519(&mut self, suci: Vec<u8>) {
+        self.stored_suci = Some(suci);
+        self.timers.start(TIMER_T3519, true);
     }
 
     // ========================================================================
@@ -609,6 +637,14 @@ impl MmOrchestrator {
                 self.res_star = None;
                 Vec::new()
             }
+            TIMER_T3519 => {
+                // TS 24.501 §5.4.3.3: once T3519 expires the stored SUCI may be
+                // regenerated, so drop it and let the next request build a fresh
+                // concealment.
+                debug!("T3519 expired: clearing stored SUCI");
+                self.stored_suci = None;
+                Vec::new()
+            }
             TIMER_T3520 => {
                 // TS 24.501 5.4.1.3.7: network failed to react to the
                 // authentication failure in time
@@ -697,11 +733,14 @@ impl MmOrchestrator {
         };
 
         // TS 24.501 5.5.1.2.2: use the valid 5G-GUTI when available,
-        // otherwise the SUCI
+        // otherwise the SUCI. A SUCI sent here is stored and T3519 armed so the
+        // identity/registration paths reuse it until the timer expires.
         let mobile_identity = if let Some(ref guti) = self.stored_guti {
             guti.clone()
         } else {
-            Ie5gsMobileIdentity::new(MobileIdentityType::Suci, self.identity.suci.clone())
+            let suci = self.identity.suci.clone();
+            self.store_suci_and_arm_t3519(suci.clone());
+            Ie5gsMobileIdentity::new(MobileIdentityType::Suci, suci)
         };
 
         let mut req = RegistrationRequest::new(
@@ -1794,7 +1833,10 @@ impl MmOrchestrator {
         let mobile_identity = if let Some(ref guti) = self.stored_guti {
             guti.clone()
         } else {
-            Ie5gsMobileIdentity::new(MobileIdentityType::Suci, self.identity.suci.clone())
+            // §5.5.2.2.2: store the SUCI and arm T3519 under the same rule.
+            let suci = self.identity.suci.clone();
+            self.store_suci_and_arm_t3519(suci.clone());
+            Ie5gsMobileIdentity::new(MobileIdentityType::Suci, suci)
         };
         let req = DeregistrationRequestUeOriginating::new(
             dereg_type,
@@ -3744,6 +3786,36 @@ mod tests {
             orch.state().mm_substate(),
             MmSubState::DeregisteredNormalService
         );
+    }
+
+    // TS 24.501 §5.4.3.3: the UE reuses a stored SUCI while T3519 runs and only
+    // regenerates once the timer has expired.
+    #[test]
+    fn test_suci_reuse_while_t3519_running() {
+        use crate::timer::{TimerExpiryEvent, TIMER_T3519};
+        let mut orch = new_orch();
+
+        // T3519 is not running initially, so there is nothing to reuse.
+        assert_eq!(orch.timers().is_running(TIMER_T3519), Some(false));
+        assert!(orch.stored_suci_while_t3519_running().is_none());
+
+        // First SUCI: store it and arm T3519.
+        let first = vec![0x01u8, 0x02, 0x03, 0x04];
+        orch.store_suci_and_arm_t3519(first.clone());
+        assert_eq!(orch.timers().is_running(TIMER_T3519), Some(true));
+
+        // While T3519 runs the stored SUCI is reused byte-for-byte.
+        assert_eq!(orch.stored_suci_while_t3519_running(), Some(first.clone()));
+        assert_eq!(orch.stored_suci_while_t3519_running(), Some(first));
+
+        // On T3519 expiry the stored SUCI is cleared -> caller regenerates.
+        let out = orch.handle_timer_expiry(TimerExpiryEvent {
+            timer_code: TIMER_T3519,
+            is_mm: true,
+            expiry_count: 1,
+        });
+        assert!(out.is_empty());
+        assert!(orch.stored_suci_while_t3519_running().is_none());
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

Implements the TS 24.501 §5.4.3.3 stored-SUCI-under-T3519 discipline. The UE built a fresh ECIES-concealed SUCI on every IDENTITY REQUEST, and T3519 — although defined and constructed — was never armed, so the TS 33.501 §6.12.4 frequency limit the timer exists to enforce was inert.

## Spec basis

- **TS 24.501 §5.4.3.3 b)** — on an IDENTITY REQUEST (identity type = SUCI): if T3519 is not running, generate a fresh SUCI, send it, start T3519 and store the SUCI; if T3519 is running, send the *stored* SUCI.
- **TS 24.501 §5.5.1.2.2 / §5.5.2.2.2** — the same discipline applies to a SUCI carried in REGISTRATION / DEREGISTRATION REQUEST.
- **TS 33.501 §6.12.4** — frequency-limiting of SUCI concealment; T3519 is the mechanism.

## Changes

- `MmOrchestrator` gains a `stored_suci` cache and two methods: `stored_suci_while_t3519_running()` (reuse while T3519 runs) and `store_suci_and_arm_t3519()` (store fresh + start T3519). `handle_timer_expiry` clears the stored SUCI on T3519 expiry.
- The IDENTITY REQUEST handler (`nextgsim-ue/src/main.rs`) reuses the stored SUCI while T3519 runs and otherwise builds a fresh one, stores it and arms T3519.
- The SUCI branch of `build_and_send_registration` and `start_deregistration` stores the SUCI and arms T3519 (§5.5.1.2.2 / §5.5.2.2.2).
- Unit test `test_suci_reuse_while_t3519_running` asserts: nothing to reuse when T3519 is off; byte-identical reuse while it runs; cleared after expiry.

## Verification

- `cargo clippy --workspace --all-targets` — exit 0 (no new warnings).
- `cargo test --workspace` — exit 0 (145 MM tests pass, including the registration/dereg paths that now arm T3519).

Closes #52
