### PR TITLE
refactor(nwdaf): honesty + resilience fixes in nextgsim-nwdaf (#59)

### DIFF
--- a/nextgsim-nwdaf/src/analytics_id.rs
+++ b/nextgsim-nwdaf/src/analytics_id.rs
@@ -30,7 +30,7 @@ pub enum AnalyticsId {
     /// including MOS scores and service-level KPIs.
     ServiceExperience,
 
-    /// Abnormal Behaviour analytics (clause 6.9)
+    /// Abnormal Behaviour analytics (clause 6.7, UE-related analytics)
     ///
     /// Detects anomalous behavior patterns in UEs or network elements,
     /// using statistical analysis and ML-based detection.
@@ -42,7 +42,7 @@ pub enum AnalyticsId {
     /// including per-cell and per-slice congestion levels.
     UserDataCongestion,
 
-    /// `QoS` Sustainability analytics (clause 6.6)
+    /// `QoS` Sustainability analytics (clause 6.9)
     ///
     /// Predicts whether current `QoS` levels can be maintained,
     /// considering network conditions and resource availability.
@@ -82,9 +82,9 @@ impl AnalyticsId {
             AnalyticsId::UeMobility => "6.7",
             AnalyticsId::NfLoad => "6.5",
             AnalyticsId::ServiceExperience => "6.4",
-            AnalyticsId::AbnormalBehavior => "6.9",
+            AnalyticsId::AbnormalBehavior => "6.7",
             AnalyticsId::UserDataCongestion => "6.8",
-            AnalyticsId::QosSustainability => "6.6",
+            AnalyticsId::QosSustainability => "6.9",
             AnalyticsId::EnergyEfficiency => "Rel-19",
             AnalyticsId::SliceOptimization => "Rel-19",
         }
@@ -186,6 +186,17 @@ pub enum AnalyticsOutputType {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_clause_references_match_ts23288() {
+        // TS 23.288 §6.4–§6.9 mapping (the two swapped citations are corrected).
+        assert_eq!(AnalyticsId::ServiceExperience.clause_reference(), "6.4");
+        assert_eq!(AnalyticsId::NfLoad.clause_reference(), "6.5");
+        assert_eq!(AnalyticsId::UeMobility.clause_reference(), "6.7");
+        assert_eq!(AnalyticsId::AbnormalBehavior.clause_reference(), "6.7");
+        assert_eq!(AnalyticsId::UserDataCongestion.clause_reference(), "6.8");
+        assert_eq!(AnalyticsId::QosSustainability.clause_reference(), "6.9");
+    }
 
     #[test]
     fn test_analytics_id_all() {

--- a/nextgsim-nwdaf/src/anlf.rs
+++ b/nextgsim-nwdaf/src/anlf.rs
@@ -1070,7 +1070,7 @@ impl Anlf {
         }
     }
 
-    /// Performs `QoS` Sustainability analytics (TS 23.288 6.6)
+    /// Performs `QoS` Sustainability analytics (TS 23.288 6.9)
     ///
     /// Predicts whether current `QoS` levels can be sustained given network conditions.
     ///

--- a/nextgsim-nwdaf/src/event_exposure.rs
+++ b/nextgsim-nwdaf/src/event_exposure.rs
@@ -187,10 +187,14 @@ pub enum MobilityState {
 }
 
 /// Event exposure manager
+/// Upper bound on retained event notifications. Prevents unbounded growth on
+/// long-lived runs; the oldest entries are evicted first once the cap is hit.
+const MAX_NOTIFICATIONS: usize = 10_000;
+
 pub struct EventExposureManager {
     /// Active subscriptions
     subscriptions: HashMap<String, EventSubscription>,
-    /// Received event notifications
+    /// Received event notifications (bounded at `MAX_NOTIFICATIONS`)
     notifications: Vec<EventNotification>,
     /// Next subscription ID counter
     next_subscription_id: u64,
@@ -277,6 +281,10 @@ impl EventExposureManager {
             }
         })?;
 
+        // Drop notifications belonging to the removed subscription so they do
+        // not accumulate for a subscription that can no longer be queried.
+        self.notifications
+            .retain(|n| n.subscription_id != subscription_id);
         info!("Deleted event subscription: {}", subscription_id);
         Ok(())
     }
@@ -289,6 +297,11 @@ impl EventExposureManager {
         );
 
         self.notifications.push(notification);
+        // Bound the buffer: evict the oldest entries once the cap is exceeded.
+        if self.notifications.len() > MAX_NOTIFICATIONS {
+            let excess = self.notifications.len() - MAX_NOTIFICATIONS;
+            self.notifications.drain(0..excess);
+        }
     }
 
     /// Gets all notifications for a subscription
@@ -337,6 +350,38 @@ impl Default for EventExposureManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_notifications_bounded_and_pruned_on_delete() {
+        let mut manager = EventExposureManager::new();
+        let sub = manager.create_subscription(
+            EventType::LoadLevel,
+            NfType::Amf,
+            "http://nwdaf:8080/notify".to_string(),
+            Some(60),
+        );
+        let make = |id: &str| EventNotification {
+            subscription_id: id.to_string(),
+            event_type: EventType::LoadLevel,
+            nf_instance_id: "amf-001".to_string(),
+            event_data: EventData::LoadLevel {
+                load_percentage: 50,
+                registered_ues: 10,
+            },
+            timestamp_ms: 0,
+        };
+        // Bounded: pushing past the cap keeps the buffer within MAX_NOTIFICATIONS.
+        for _ in 0..(MAX_NOTIFICATIONS + 25) {
+            manager.receive_notification(make(&sub.subscription_id));
+        }
+        assert!(manager.notifications.len() <= MAX_NOTIFICATIONS);
+        // Pruned on delete: the deleted subscription's notifications are dropped.
+        manager.delete_subscription(&sub.subscription_id).unwrap();
+        assert!(manager
+            .notifications
+            .iter()
+            .all(|n| n.subscription_id != sub.subscription_id));
+    }
 
     #[test]
     fn test_create_subscription() {

--- a/nextgsim-nwdaf/src/federation.rs
+++ b/nextgsim-nwdaf/src/federation.rs
@@ -1,6 +1,8 @@
 //! Cross-Operator Data Federation (TS 23.288 / TS 29.520)
 //!
-//! Implements privacy-preserving analytics sharing across PLMN boundaries.
+//! Research prototype modelling cross-PLMN analytics sharing. It applies
+//! k-anonymity thresholds, subscriber-ID stripping and location generalization,
+//! but provides **no** differential-privacy guarantee.
 //!
 //! # Architecture
 //!
@@ -11,7 +13,7 @@
 //! │  ┌─────────────────────┐      ┌─────────────────────────────────┐   │
 //! │  │ Federation Registry │      │ Privacy Controller               │   │
 //! │  │  • Peer operators    │      │  • K-anonymity enforcement       │   │
-//! │  │  • Trust levels      │      │  • Differential privacy noise    │   │
+//! │  │  • Trust levels      │      │  • Location generalization    │   │
 //! │  │  • Roaming partners  │      │  • Data minimization             │   │
 //! │  └─────────────────────┘      │  • Consent tracking              │   │
 //! │                                └─────────────────────────────────┘   │
@@ -112,8 +114,6 @@ pub struct FederationPeer {
 pub struct PrivacyPolicy {
     /// Minimum group size for k-anonymity (default: 5)
     pub k_anonymity_threshold: usize,
-    /// Epsilon parameter for differential privacy noise (default: 1.0)
-    pub dp_epsilon: f64,
     /// Whether to strip subscriber identities from shared data
     pub strip_subscriber_ids: bool,
     /// Whether to generalize location data (round to cell level)
@@ -128,7 +128,6 @@ impl Default for PrivacyPolicy {
     fn default() -> Self {
         Self {
             k_anonymity_threshold: 5,
-            dp_epsilon: 1.0,
             strip_subscriber_ids: true,
             generalize_location: true,
             retention_seconds: 86_400, // 24 hours
@@ -316,8 +315,8 @@ impl DataFederationManager {
     /// Updates the privacy policy.
     pub fn set_privacy_policy(&mut self, policy: PrivacyPolicy) {
         info!(
-            "Updating privacy policy (k={}, epsilon={:.2})",
-            policy.k_anonymity_threshold, policy.dp_epsilon
+            "Updating privacy policy (k={})",
+            policy.k_anonymity_threshold
         );
         self.privacy_policy = policy;
     }
@@ -750,12 +749,6 @@ impl DataFederationManager {
             .map(|r| {
                 let mut filtered = r.clone();
 
-                // Apply differential privacy noise to confidence scores
-                if trust_level <= TrustLevel::Basic {
-                    let noise = laplace_noise(self.privacy_policy.dp_epsilon);
-                    filtered.confidence = (filtered.confidence + noise as f32).clamp(0.0, 1.0);
-                }
-
                 // Generalize location data for lower trust levels
                 if self.privacy_policy.generalize_location && trust_level < TrustLevel::Full {
                     filtered.area = filtered.area.map(|mut a| {
@@ -807,20 +800,6 @@ impl DataFederationManager {
             entry.0 += 1;
         }
     }
-}
-
-/// Simple deterministic Laplace-like noise for differential privacy.
-///
-/// In production this would use a cryptographic PRNG; here we use a
-/// simplified version for simulation purposes.
-fn laplace_noise(epsilon: f64) -> f64 {
-    // Deterministic small perturbation scaled by 1/epsilon
-    // Real implementation would sample from Laplace(0, 1/epsilon)
-    let scale = 1.0 / epsilon;
-    // Use a simple hash of the current time for reproducible noise
-    let t = current_time_ms();
-    let pseudo_uniform = ((t % 1000) as f64 / 1000.0) - 0.5; // [-0.5, 0.5)
-    -scale * pseudo_uniform.signum() * (1.0 - 2.0 * pseudo_uniform.abs()).ln()
 }
 
 /// Returns the current time in milliseconds since epoch.
@@ -1188,7 +1167,6 @@ mod tests {
     fn test_privacy_policy_custom() {
         let policy = PrivacyPolicy {
             k_anonymity_threshold: 10,
-            dp_epsilon: 0.5,
             strip_subscriber_ids: true,
             generalize_location: true,
             retention_seconds: 3600,
@@ -1198,7 +1176,6 @@ mod tests {
         let mgr = DataFederationManager::with_privacy_policy(PlmnId::new("001", "01"), policy);
 
         assert_eq!(mgr.privacy_policy().k_anonymity_threshold, 10);
-        assert_eq!(mgr.privacy_policy().dp_epsilon, 0.5);
     }
 
     #[test]

--- a/nextgsim-nwdaf/src/lib.rs
+++ b/nextgsim-nwdaf/src/lib.rs
@@ -1,6 +1,11 @@
 //! Network Data Analytics Function (NWDAF) for 6G Networks
 //!
-//! Implements NWDAF per 3GPP TS 23.288 with four-layer analytics:
+//! This crate is a **research prototype**. It is architecturally aligned with the
+//! NWDAF analytics concepts of 3GPP TS 23.288, but runs entirely in-process: it
+//! implements no Nnwdaf SBI surface, no TS 29.500 ProblemDetails error model and
+//! no notification correlation IDs, and it is not conformance-tested.
+//!
+//! It models a four-layer analytics stack:
 //! - Layer 1: Real-time anomaly detection
 //! - Layer 2: Predictive analytics (trajectory, load)
 //! - Layer 3: Prescriptive optimization
@@ -51,7 +56,7 @@
 //! └─────────────────────────────────────────────────────────────────────────┘
 //! ```
 //!
-//! # 3GPP Compliance
+//! # 3GPP Alignment
 //!
 //! This implementation aligns with:
 //! - 3GPP TS 23.288: Network Data Analytics Services

--- a/nextgsim-nwdaf/src/llm_analytics.rs
+++ b/nextgsim-nwdaf/src/llm_analytics.rs
@@ -1,7 +1,10 @@
-//! LLM-based Analytics Integration
+//! Keyword-templated analytics mock (placeholder for LLM integration)
 //!
-//! Integrates Large Language Models for advanced network analytics using NKEF
-//! as the knowledge backend (RAG - Retrieval Augmented Generation).
+//! This module does **not** run a Large Language Model or perform NKEF-based
+//! RAG. `query()` pattern-matches substrings of the request and returns
+//! hardcoded narrative templates; it consults no knowledge store and computes
+//! no model score. A real LLM/RAG path would route through `nextgsim-ai` / NKEF
+//! behind a dedicated feature.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -52,10 +55,10 @@ pub struct LlmAnalyticsResponse {
     pub related_analytics: Vec<AnalyticsId>,
 }
 
-/// LLM analytics engine
+/// Analytics query engine (keyword-templated mock).
 ///
-/// Provides natural language interface to network analytics using LLMs
-/// with NKEF-based RAG for grounding responses in actual network state.
+/// Returns hardcoded narrative templates keyed off substrings of the query; it
+/// does not invoke an LLM or NKEF/RAG and grounds nothing in live state.
 #[derive(Debug)]
 pub struct LlmAnalyticsEngine {
     /// Whether engine is enabled
@@ -204,14 +207,14 @@ impl LlmAnalyticsEngine {
             )
         };
 
+        // The keyword-templated mock consults no knowledge store, so it reports
+        // no sources; `confidence` is a coarse placeholder (higher when the query
+        // matched a known analytics template) and is NOT a computed model score.
+        let confidence = if related_analytics.is_empty() { 0.2 } else { 0.5 };
         LlmAnalyticsResponse {
             response,
-            confidence: 0.75,
-            sources: vec![
-                "NKEF knowledge graph".to_string(),
-                "UE mobility analytics".to_string(),
-                "Cell load history".to_string(),
-            ],
+            confidence,
+            sources: Vec::new(),
             suggested_actions: actions,
             related_analytics,
         }
@@ -242,6 +245,31 @@ impl Default for LlmAnalyticsEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_mock_response_no_fabricated_provenance() {
+        let mut engine = LlmAnalyticsEngine::new(true);
+        let r1 = engine
+            .query(LlmAnalyticsQuery {
+                query: "mobility trends".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let r2 = engine
+            .query(LlmAnalyticsQuery {
+                query: "unclassified request".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        // The mock consults no knowledge store: no fabricated RAG provenance.
+        assert!(r1.sources.is_empty());
+        assert!(r2.sources.is_empty());
+        // Confidence is no longer the fabricated fixed 0.75 literal, and a
+        // matched template differs from the generic fallback.
+        assert_ne!(r1.confidence, 0.75);
+        assert_ne!(r2.confidence, 0.75);
+        assert_ne!(r1.confidence, r2.confidence);
+    }
 
     #[test]
     fn test_llm_engine_creation() {


### PR DESCRIPTION
## Summary

Five same-crate honesty and hygiene corrections in `nextgsim-nwdaf`, aligning the crate's claims with its behaviour and removing a memory leak. No new features.

## Changes

- **llm_analytics** — module/struct docs no longer claim real LLM inference or NKEF-based RAG. The keyword-templated mock now returns empty `sources` (it consults no knowledge store) and a placeholder `confidence` (higher when a template matched) instead of a fabricated three-element provenance list and a fixed `0.75`.
- **federation** — removes the false "differential privacy" claim: drops the `dp_epsilon` knob, the deterministic time-seeded `laplace_noise`, and the DP framing in docs. k-anonymity, subscriber-ID stripping and location generalization remain.
- **analytics_id / anlf** — corrects two swapped TS 23.288 citations: `QosSustainability` 6.6 → 6.9, `AbnormalBehavior` 6.9 → 6.7.
- **lib.rs** — adds the sibling-style research-prototype disclaimer (in-process, no Nnwdaf SBI / ProblemDetails) and rewords the "3GPP Compliance" heading to "3GPP Alignment".
- **event_exposure** — bounds the notification buffer at `MAX_NOTIFICATIONS` (oldest evicted) and prunes a subscription's notifications in `delete_subscription()`, fixing monotonic memory growth.

## Verification

- `cargo test -p nextgsim-nwdaf` — 194 tests pass, including new tests for the clause mapping, the de-fabricated LLM response, and the bounded/pruned notification buffer.
- `cargo clippy --workspace --all-targets` and `cargo test --workspace` — green.

Closes #59
