### PR TITLE
fix(gnb): remove dead RedCap PRB clamp + false enforcement claims (#57)

### DIFF
--- a/nextgsim-gnb/src/rrc/task.rs
+++ b/nextgsim-gnb/src/rrc/task.rs
@@ -510,8 +510,9 @@ impl RrcTask {
     /// The scheduler enforces a reduced serving bandwidth for a RedCap UE: the
     /// cell's PRB grid is clamped to the RedCap maximum bandwidth (20 MHz for
     /// Rel-17), so a RedCap UE is never granted more PRBs than its narrowband
-    /// RF supports. The enforced PRB ceiling is stored on the UE context and
-    /// observed by downstream resource allocation.
+    /// RF supports. This is modelled only: the functional simulator has no PRB
+    /// scheduler, so the computed ceiling is logged, not enforced on a resource
+    /// grid.
     fn apply_redcap_restrictions(&mut self, ue_id: i32) {
         // Cell serving bandwidth (FR1 normal UE baseline: 100 MHz / 273 PRB at
         // 30 kHz SCS, TS 38.101-1 Table 5.3.2-1).
@@ -527,14 +528,12 @@ impl RrcTask {
         ctx.redcap
             .configure(super::redcap::RedCapUeCapabilities::rel17());
 
-        // Scheduler enforcement: clamp the granted bandwidth to the RedCap
-        // ceiling and translate it to a hard PRB cap proportional to the
-        // bandwidth reduction. This is a real reduction applied to this UE's
-        // resource grid, not a log-only marker.
+        // Model the RedCap bandwidth restriction and derive the equivalent PRB
+        // ceiling for logging. This functional simulator has no PRB scheduler,
+        // so the ceiling is reported, not enforced on a resource grid.
         let enforced_bw_mhz = ctx.redcap.restrict_bandwidth(CELL_BANDWIDTH_MHZ);
         let enforced_max_prb =
             (CELL_MAX_PRB * enforced_bw_mhz as u32 / CELL_BANDWIDTH_MHZ as u32).max(1);
-        ctx.set_redcap_max_prb(enforced_max_prb);
 
         info!(
             "RedCap UE[{}]: scheduler bandwidth restricted to {} MHz ({} PRB max, \

--- a/nextgsim-gnb/src/rrc/ue_context.rs
+++ b/nextgsim-gnb/src/rrc/ue_context.rs
@@ -66,10 +66,6 @@ pub struct RrcUeContext {
     pub state: RrcState,
     /// RedCap processor for this UE (Rel-17)
     pub redcap: RedCapProcessor,
-    /// Scheduler PRB ceiling enforced for this UE. `None` for a normal UE
-    /// (full cell bandwidth); `Some(prb)` for a RedCap UE whose serving
-    /// bandwidth has been clamped to its narrowband RF capability (Rel-17).
-    pub redcap_max_prb: Option<u32>,
     /// UPER-encoded UE-NR-Capability container from UECapabilityInformation
     pub nr_capability: Option<Vec<u8>>,
     /// Per-UE RRC transaction-identifier allocator (TS 38.331 §6.3.2, Wave-6
@@ -90,7 +86,6 @@ impl RrcUeContext {
             s_tmsi: None,
             state: RrcState::Idle,
             redcap: RedCapProcessor::new(),
-            redcap_max_prb: None,
             nr_capability: None,
             transactions: RrcTransactionAllocator::new(),
         }
@@ -99,17 +94,6 @@ impl RrcUeContext {
     /// Stores the UE-NR-Capability container received in UECapabilityInformation
     pub fn set_nr_capability(&mut self, container: Vec<u8>) {
         self.nr_capability = Some(container);
-    }
-
-    /// Stores the scheduler PRB ceiling enforced for a RedCap UE (Rel-17).
-    pub fn set_redcap_max_prb(&mut self, max_prb: u32) {
-        self.redcap_max_prb = Some(max_prb);
-    }
-
-    /// Returns the scheduler PRB ceiling for this UE: the RedCap-restricted
-    /// value when set, otherwise the full cell PRB count (normal UE).
-    pub fn scheduler_max_prb(&self, cell_max_prb: u32) -> u32 {
-        self.redcap_max_prb.unwrap_or(cell_max_prb)
     }
 
     /// Sets the initial UE identity


### PR DESCRIPTION
## Summary

Removes the dead RedCap PRB clamp and the false enforcement comments in the gNB. This addresses the PRB-clamp/honesty half of #57; the Rel-17 RRC/SIB1 codec upgrade remains open there.

## Problem

`apply_redcap_restrictions` computed and stored a `redcap_max_prb` ceiling via `set_redcap_max_prb()`, exposed through `scheduler_max_prb()` — but that getter had **zero callers**. The functional gNB has no PRB scheduler/resource-grid to enforce a per-UE ceiling. Two comments nonetheless asserted "a real reduction applied to this UE's resource grid, not a log-only marker" (`task.rs`) and that the ceiling was "observed by downstream resource allocation" (`ue_context.rs`), neither of which happens.

## Changes

- Delete the unused `redcap_max_prb` field, `set_redcap_max_prb()` and `scheduler_max_prb()` from `RrcUeContext`.
- Reword the `apply_redcap_restrictions` doc/comment to state honestly that the RedCap bandwidth restriction is **modelled and logged, not enforced** (the sim has no PRB scheduler). The RedCap processor configuration and the informational log line are retained.
- A grep for `scheduler_max_prb` / `redcap_max_prb` / `set_redcap_max_prb` now returns nothing (no orphaned getter).

## Scope

Partially addresses #57. Satisfies its dead-clamp criterion ("delete `redcap_max_prb`/`scheduler_max_prb()`") and its false-comment criterion. **Not** in this PR (remains in #57): upgrading the RRCSetupComplete / SIB1 codecs to Rel-17 so `redCapIndication` and `intraFreqReselectionRedCap` round-trip as real `v1700` IEs rather than private `lateNonCriticalExtension` markers.

## Verification

- `cargo clippy --workspace --all-targets` and `cargo test --workspace` — green.

Related: #57
