### PR TITLE
refactor(rls): rename RLS wire coordinate Vector3 -> SimCoord (#26)

### DIFF
--- a/nextgsim-gnb/src/rls/task.rs
+++ b/nextgsim-gnb/src/rls/task.rs
@@ -20,7 +20,7 @@ use nextgsim_rlc::{RlcEntity, RlcMode, SnSize};
 use nextgsim_rls::{
     codec, GnbCellTracker, GnbTrackerEvent, PduType, RlsHeartbeatAck,
     RlsMessage as RlsProtocolMessage, RlsPduTransmission, RlsPduTransmissionAck, RrcChannel,
-    Vector3,
+    SimCoord,
 };
 
 /// Default RLS port for gNB
@@ -60,7 +60,7 @@ impl RlsTask {
     pub fn new(task_base: GnbTaskBase) -> Self {
         // Generate STI from gNB NCI
         let sti = task_base.config.nci;
-        let phy_location = Vector3::new(0, 0, 0);
+        let phy_location = SimCoord::new(0, 0, 0);
 
         // Get bind address from config
         let bind_address = SocketAddr::new(task_base.config.link_ip, DEFAULT_RLS_PORT);
@@ -81,7 +81,7 @@ impl RlsTask {
     /// Creates a new RLS task with custom bind address
     pub fn with_bind_address(task_base: GnbTaskBase, bind_address: SocketAddr) -> Self {
         let sti = task_base.config.nci;
-        let phy_location = Vector3::new(0, 0, 0);
+        let phy_location = SimCoord::new(0, 0, 0);
 
         Self {
             task_base,

--- a/nextgsim-rls/src/cell_search.rs
+++ b/nextgsim-rls/src/cell_search.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 
-use crate::protocol::{RlsHeartbeat, RlsHeartbeatAck, Vector3};
+use crate::protocol::{RlsHeartbeat, RlsHeartbeatAck, SimCoord};
 
 /// Default heartbeat interval in milliseconds
 pub const DEFAULT_HEARTBEAT_INTERVAL_MS: u64 = 1000;
@@ -95,7 +95,7 @@ pub struct UeCellSearch {
     /// UE's STI (Simulated Transmission Identifier)
     sti: u64,
     /// UE's simulated position
-    sim_pos: Vector3,
+    sim_pos: SimCoord,
     /// Search space (addresses to send heartbeats to)
     search_space: Vec<SocketAddr>,
     /// Discovered cells indexed by STI
@@ -117,7 +117,7 @@ impl UeCellSearch {
     pub fn new(sti: u64, search_space: Vec<SocketAddr>) -> Self {
         Self {
             sti,
-            sim_pos: Vector3::default(),
+            sim_pos: SimCoord::default(),
             search_space,
             cells: HashMap::new(),
             cell_id_to_sti: HashMap::new(),
@@ -129,7 +129,7 @@ impl UeCellSearch {
     }
 
     /// Sets the UE's simulated position
-    pub fn set_position(&mut self, pos: Vector3) {
+    pub fn set_position(&mut self, pos: SimCoord) {
         self.sim_pos = pos;
     }
 
@@ -264,7 +264,7 @@ pub struct GnbCellTracker {
     /// gNB's STI (Simulated Transmission Identifier)
     sti: u64,
     /// gNB's physical location for signal strength calculation
-    phy_location: Vector3,
+    phy_location: SimCoord,
     /// Tracked UEs indexed by STI
     ues: HashMap<u64, UeInfo>,
     /// Mapping from `ue_id` to STI
@@ -330,7 +330,7 @@ pub enum GnbTrackerEvent {
 
 impl GnbCellTracker {
     /// Creates a new gNB cell tracker
-    pub fn new(sti: u64, phy_location: Vector3) -> Self {
+    pub fn new(sti: u64, phy_location: SimCoord) -> Self {
         Self {
             sti,
             phy_location,
@@ -347,7 +347,7 @@ impl GnbCellTracker {
     }
 
     /// Estimates signal strength based on distance
-    pub fn estimate_dbm(&self, ue_pos: &Vector3) -> i32 {
+    pub fn estimate_dbm(&self, ue_pos: &SimCoord) -> i32 {
         let dx = self.phy_location.x - ue_pos.x;
         let dy = self.phy_location.y - ue_pos.y;
         let dz = self.phy_location.z - ue_pos.z;
@@ -497,9 +497,9 @@ mod tests {
 
     #[test]
     fn test_gnb_tracker_detection() {
-        let mut tracker = GnbCellTracker::new(67890, Vector3::new(0, 0, 0));
+        let mut tracker = GnbCellTracker::new(67890, SimCoord::new(0, 0, 0));
 
-        let heartbeat = RlsHeartbeat::with_position(12345, Vector3::new(10, 0, 0));
+        let heartbeat = RlsHeartbeat::with_position(12345, SimCoord::new(10, 0, 0));
         let (ack, events) = tracker.process_heartbeat(12345, test_addr(5000), &heartbeat);
 
         assert!(ack.is_some());
@@ -517,10 +517,10 @@ mod tests {
 
     #[test]
     fn test_gnb_tracker_weak_signal() {
-        let mut tracker = GnbCellTracker::new(67890, Vector3::new(0, 0, 0));
+        let mut tracker = GnbCellTracker::new(67890, SimCoord::new(0, 0, 0));
 
         // UE very far away
-        let heartbeat = RlsHeartbeat::with_position(12345, Vector3::new(1000, 0, 0));
+        let heartbeat = RlsHeartbeat::with_position(12345, SimCoord::new(1000, 0, 0));
         let (ack, events) = tracker.process_heartbeat(12345, test_addr(5000), &heartbeat);
 
         // Signal too weak, should be ignored
@@ -532,7 +532,7 @@ mod tests {
     #[test]
     fn test_create_heartbeats() {
         let mut search = UeCellSearch::new(12345, vec![test_addr(4997), test_addr(4998)]);
-        search.set_position(Vector3::new(100, 200, 0));
+        search.set_position(SimCoord::new(100, 200, 0));
 
         let heartbeats = search.create_heartbeats();
 

--- a/nextgsim-rls/src/codec.rs
+++ b/nextgsim-rls/src/codec.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 use crate::protocol::{
     version, MessageType, PduType, RlsHeartbeat, RlsHeartbeatAck, RlsMessage, RlsPduTransmission,
-    RlsPduTransmissionAck, Vector3,
+    RlsPduTransmissionAck, SimCoord,
 };
 
 /// Maximum PDU length allowed (16KB)
@@ -174,7 +174,7 @@ fn decode_heartbeat(sti: u64, mut buf: &[u8]) -> Result<RlsMessage> {
 
     Ok(RlsMessage::Heartbeat(RlsHeartbeat::with_position(
         sti,
-        Vector3::new(x, y, z),
+        SimCoord::new(x, y, z),
     )))
 }
 
@@ -267,7 +267,7 @@ mod tests {
     fn test_heartbeat_roundtrip() {
         let msg = RlsMessage::Heartbeat(RlsHeartbeat::with_position(
             0x123456789ABCDEF0,
-            Vector3::new(100, -200, 300),
+            SimCoord::new(100, -200, 300),
         ));
 
         let encoded = encode(&msg);

--- a/nextgsim-rls/src/lib.rs
+++ b/nextgsim-rls/src/lib.rs
@@ -24,13 +24,13 @@
 //! # Example
 //!
 //! ```rust
-//! use nextgsim_rls::protocol::{RlsMessage, RlsHeartbeat, Vector3};
+//! use nextgsim_rls::protocol::{RlsMessage, RlsHeartbeat, SimCoord};
 //! use nextgsim_rls::codec;
 //!
 //! // Create a heartbeat message
 //! let heartbeat = RlsMessage::Heartbeat(RlsHeartbeat::with_position(
 //!     12345,
-//!     Vector3::new(100, 200, 0),
+//!     SimCoord::new(100, 200, 0),
 //! ));
 //!
 //! // Encode for transmission
@@ -45,7 +45,7 @@
 //!
 //! ```rust
 //! use nextgsim_rls::cell_search::{UeCellSearch, GnbCellTracker};
-//! use nextgsim_rls::protocol::Vector3;
+//! use nextgsim_rls::protocol::SimCoord;
 //! use std::net::SocketAddr;
 //!
 //! // UE side: create cell search manager
@@ -56,7 +56,7 @@
 //! let heartbeats = ue_search.create_heartbeats();
 //!
 //! // gNB side: create cell tracker
-//! let mut gnb_tracker = GnbCellTracker::new(67890, Vector3::new(0, 0, 0));
+//! let mut gnb_tracker = GnbCellTracker::new(67890, SimCoord::new(0, 0, 0));
 //! ```
 
 pub mod cell_search;
@@ -68,7 +68,7 @@ pub mod transport;
 pub use codec::{decode, encode, RlsCodecError};
 pub use protocol::{
     MessageType, PduInfo, PduType, RlfCause, RlsHeartbeat, RlsHeartbeatAck, RlsMessage,
-    RlsPduTransmission, RlsPduTransmissionAck, Vector3,
+    RlsPduTransmission, RlsPduTransmissionAck, SimCoord,
 };
 
 // Re-export cell search types

--- a/nextgsim-rls/src/protocol.rs
+++ b/nextgsim-rls/src/protocol.rs
@@ -80,9 +80,13 @@ impl PduType {
     }
 }
 
-/// 3D position vector for simulated radio positioning
+/// Integer 3D coordinate for the RLS ("Radio Link Simulation") wire protocol.
+///
+/// Serialized as three big-endian `i32`s (see [`crate::codec`]) and `Eq`/`Hash`
+/// compatible for use in `RlsMessage` / `RlsHeartbeat`. Distinct from the
+/// floating-point `nextgsim_common::Vector3` used for sensing/positioning math.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct Vector3 {
+pub struct SimCoord {
     /// X coordinate
     pub x: i32,
     /// Y coordinate
@@ -91,14 +95,14 @@ pub struct Vector3 {
     pub z: i32,
 }
 
-impl Vector3 {
-    /// Creates a new Vector3 with the given coordinates
+impl SimCoord {
+    /// Creates a new SimCoord with the given coordinates
     pub const fn new(x: i32, y: i32, z: i32) -> Self {
         Self { x, y, z }
     }
 }
 
-impl fmt::Display for Vector3 {
+impl fmt::Display for SimCoord {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "({}, {}, {})", self.x, self.y, self.z)
     }
@@ -156,7 +160,7 @@ pub struct RlsHeartbeat {
     /// Simulated Transmission Identifier - unique identifier for the sender
     pub sti: u64,
     /// Simulated position of the UE
-    pub sim_pos: Vector3,
+    pub sim_pos: SimCoord,
 }
 
 impl RlsHeartbeat {
@@ -164,12 +168,12 @@ impl RlsHeartbeat {
     pub fn new(sti: u64) -> Self {
         Self {
             sti,
-            sim_pos: Vector3::default(),
+            sim_pos: SimCoord::default(),
         }
     }
 
     /// Creates a new heartbeat message with position
-    pub fn with_position(sti: u64, sim_pos: Vector3) -> Self {
+    pub fn with_position(sti: u64, sim_pos: SimCoord) -> Self {
         Self { sti, sim_pos }
     }
 }
@@ -341,7 +345,7 @@ mod tests {
 
     #[test]
     fn test_vector3() {
-        let v = Vector3::new(1, 2, 3);
+        let v = SimCoord::new(1, 2, 3);
         assert_eq!(v.x, 1);
         assert_eq!(v.y, 2);
         assert_eq!(v.z, 3);
@@ -350,7 +354,7 @@ mod tests {
 
     #[test]
     fn test_heartbeat() {
-        let hb = RlsHeartbeat::with_position(12345, Vector3::new(100, 200, 300));
+        let hb = RlsHeartbeat::with_position(12345, SimCoord::new(100, 200, 300));
         assert_eq!(hb.sti, 12345);
         assert_eq!(hb.sim_pos.x, 100);
     }


### PR DESCRIPTION
## Summary

Resolves the last `Vector3` name collision. `nextgsim-rls` defined a second struct named `Vector3` — an integer `i32` wire coordinate — distinct from the canonical floating-point `nextgsim_common::Vector3`. The RLS type cannot merge into the common one (i32 fields, `Eq`/`Hash` requirement, `const fn`, fixed 12-byte big-endian wire format), so this renames it to `SimCoord`.

## Changes

- Rename `Vector3` → `SimCoord` in `nextgsim-rls` (`protocol.rs`, `codec.rs`, `cell_search.rs`, `lib.rs` incl. doc examples) and its one external consumer `nextgsim-gnb/src/rls/task.rs` (import + two `SimCoord::new(0, 0, 0)` call sites).
- Add a doc comment on `SimCoord` noting it is the integer RLS-wire coordinate, distinct from the floating-point `nextgsim_common::Vector3`.
- No behaviour or wire-format change; retains `Copy`/`PartialEq`/`Eq`/`Default`/`const fn new`/`Display`.
- `nextgsim-nwdaf`, `nextgsim-isac` (already re-export the common type) and the f64 `Vector3` call sites in `nextgsim-gnb/src/{nwdaf,isac}/task.rs` and `tests/` are untouched.

## Verification

- `grep -rn "pub struct Vector3" --include="*.rs"` now returns exactly one hit: `nextgsim-common/src/types.rs`.
- `cargo test -p nextgsim-rls` (codec round-trip / 12-byte heartbeat unchanged), `cargo build -p nextgsim-gnb`, and the full workspace `cargo clippy --all-targets` + `cargo test` are green.

Closes #26
