### PR TITLE
fix(ue): stop advertising unwired ranging as TS 23.586-compliant (#55)

### DIFF
--- a/nextgsim-ue/src/main.rs
+++ b/nextgsim-ue/src/main.rs
@@ -370,7 +370,7 @@ impl UeApp {
         } = rel18_rxs;
         let mut ranging_task = RangingTask::new(task_base.clone());
         tokio::spawn(async move { ranging_task.run(ranging_rx).await });
-        info!("Ranging task spawned (Rel-18, TS 23.586)");
+        info!("Ranging task spawned (scaffold: no stimulus producer or UE->LMF transport)");
         let mut mint_task = MintTask::new(task_base.clone());
         tokio::spawn(async move { mint_task.run(mint_rx).await });
         info!("MINT task spawned (Rel-18, TS 23.761)");

--- a/nextgsim-ue/src/ranging/task.rs
+++ b/nextgsim-ue/src/ranging/task.rs
@@ -1,10 +1,10 @@
 //! Ranging Task for UE - UE-to-UE distance measurement and carrier phase positioning
 //!
-//! Implements Rel-18 ranging service per TS 23.586:
-//! - Round-trip time (RTT) based ranging
-//! - Carrier phase measurement for cm-level accuracy
-//! - Phase ambiguity resolution via multi-frequency combining
-//! - Ranging result reporting to LMF
+//! **Scaffold, not wired end-to-end.** Models the Rel-18 ranging concepts of
+//! TS 23.586 (RTT ranging, carrier-phase measurement with multi-frequency
+//! ambiguity resolution, and LMF result reporting), but no `RangingMessage`
+//! producer, SL-PRS stimulus, or UE->LMF (SLPP/RSPP) transport is wired — so
+//! the measurement handlers below are not reached at runtime.
 
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
@@ -157,7 +157,7 @@ impl Task for RangingTask {
     type Message = RangingMessage;
 
     async fn run(&mut self, mut rx: mpsc::Receiver<TaskMessage<Self::Message>>) {
-        info!("Ranging task started (Rel-18, TS 23.586)");
+        info!("Ranging task started (scaffold: the sidelink-positioning pipeline is not wired end-to-end)");
         loop {
             match rx.recv().await {
                 Some(TaskMessage::Message(msg)) => match msg {


### PR DESCRIPTION
## Summary

Removes the false `Rel-18, TS 23.586` ranging capability advertised at UE startup. The ranging pipeline is dead end-to-end — no `RangingMessage` producer, no SL-PRS stimulus, no UE→LMF (SLPP/RSPP) transport, and `lmfd` has no ranging service — yet two startup logs claimed spec compliance, firing even on a default (ranging-disabled) start.

## Changes

- Reword the startup logs at `nextgsim-ue/src/main.rs` (task spawn) and `nextgsim-ue/src/ranging/task.rs` (task start) to state the scaffold status honestly; neither claims `TS 23.586` compliance any more.
- Soften the `ranging/task.rs` module doc-comment to mark the task as a **non-wired stub** (models the TS 23.586 concepts but no producer/stimulus/transport is wired, so the measurement handlers are unreachable at runtime).

## Scope

Partially addresses #55 — the false-capability-advertisement portion (its criteria on the `TS 23.586` startup strings and marking ranging as a non-wired stub). **Remains open in #55:** the measurement pipeline itself — SL-PRS stimulus, an SLPP/RSPP UE→LMF message set, an `Nlmf` ranging service in `lmfd`, and the ranging E2E. A default-start log-capture regression test and the follow-up increment issues are also still outstanding there.

## Verification

- `cargo build -p nextgsim-ue`, `cargo clippy --workspace --all-targets`, and `cargo test --workspace` — green. Doc/log-string change only; no logic or wire-format change.

Related: #55
