### PR TITLE
fix(ue): stop advertising unwired sidelink as an active Rel-18 capability (#54)

### DIFF
--- a/nextgsim-nwdaf/src/llm_analytics.rs
+++ b/nextgsim-nwdaf/src/llm_analytics.rs
@@ -210,7 +210,11 @@ impl LlmAnalyticsEngine {
         // The keyword-templated mock consults no knowledge store, so it reports
         // no sources; `confidence` is a coarse placeholder (higher when the query
         // matched a known analytics template) and is NOT a computed model score.
-        let confidence = if related_analytics.is_empty() { 0.2 } else { 0.5 };
+        let confidence = if related_analytics.is_empty() {
+            0.2
+        } else {
+            0.5
+        };
         LlmAnalyticsResponse {
             response,
             confidence,

--- a/nextgsim-ue/src/nas/mm/orchestrator.rs
+++ b/nextgsim-ue/src/nas/mm/orchestrator.rs
@@ -3987,17 +3987,12 @@ mod tests {
         // REGISTRATION REQUEST goes out unprotected.
         let re_registers = outs.iter().any(|o| match o {
             MmOutput::SendNasPdu(p) => {
-                p.len() >= 3
-                    && p[1] == 0x00
-                    && p[2] == u8::from(MmMessageType::RegistrationRequest)
+                p.len() >= 3 && p[1] == 0x00 && p[2] == u8::from(MmMessageType::RegistrationRequest)
             }
             _ => false,
         });
         assert!(re_registers, "re-registration must be initiated");
-        assert_eq!(
-            orch.state().mm_substate(),
-            MmSubState::RegisteredInitiated
-        );
+        assert_eq!(orch.state().mm_substate(), MmSubState::RegisteredInitiated);
     }
 
     // ========================================================================

--- a/nextgsim-ue/src/sidelink/task.rs
+++ b/nextgsim-ue/src/sidelink/task.rs
@@ -1,10 +1,11 @@
 //! Sidelink Task for UE - NR relay, discovery, PC5, and sidelink positioning
 //!
-//! Implements Rel-18 sidelink features:
-//! - NR sidelink relay (UE-to-UE relay)
-//! - Sidelink discovery procedures
-//! - PC5 link establishment
-//! - Sidelink-based positioning (cooperative positioning between UEs)
+//! **Scaffold, not wired end-to-end.** Models the Rel-18 sidelink concepts of
+//! TS 23.304 (NR sidelink relay, discovery, PC5 link establishment, cooperative
+//! positioning), but only `StartDiscovery`/`StopDiscovery` are ever sent (and
+//! only when ranging is enabled). There is no PC5 OTA exchange and no RRC
+//! `SidelinkUEInformation` / `sl-Config`, so the PC5-link, relay and positioning
+//! handlers below are unreachable at runtime.
 
 use std::collections::HashMap;
 use tokio::sync::mpsc;
@@ -99,7 +100,7 @@ impl Task for SidelinkTask {
     type Message = SidelinkMessage;
 
     async fn run(&mut self, mut rx: mpsc::Receiver<TaskMessage<Self::Message>>) {
-        info!("Sidelink task started (Rel-18 NR Sidelink)");
+        info!("Sidelink task started (scaffold: only discovery start/stop is reachable; PC5 link/relay/positioning handlers are unwired)");
         loop {
             match rx.recv().await {
                 Some(TaskMessage::Message(msg)) => match msg {


### PR DESCRIPTION
## Summary

Removes the false "active Rel-18 sidelink" advertisement. The UE logged `Sidelink task started (Rel-18 NR Sidelink)` and its module doc listed NR sidelink relay/discovery/PC5/cooperative-positioning as implemented, but the sidelink pipeline is a scaffold: only `StartDiscovery`/`StopDiscovery` are ever sent (and only when ranging is enabled); `EstablishPc5Link`, `SetRelayMode`, `RelayData`, `PositioningMeasurement`, `CooperativePositioning` have no senders; `EstablishPc5Link` fakes `Establishing`→`Active` with no OTA exchange; and there is no RRC `SidelinkUEInformation` / `sl-Config`, so the gNB never reserves sidelink resources.

## Changes

- Reword the startup log at `nextgsim-ue/src/sidelink/task.rs` to state the scaffold status honestly (no active-Rel-18 claim).
- Soften the module doc-comment to mark the task a **non-wired stub** (models TS 23.304 concepts; only discovery start/stop is reachable; PC5-link/relay/positioning handlers are unreachable at runtime).

## Scope

Partially addresses #54 — the false-capability-advertisement portion. **Remains open in #54:** a real PC5 OTA exchange, RRC `SidelinkUEInformation` / `sl-Config` so resources are reserved, and reachable relay/positioning message paths.

## Verification

- `cargo clippy --workspace --all-targets` and `cargo test --workspace` — green. Doc/log-string change only; no logic change.

Related: #54
