### PR TITLE
feat(gnb): implement NGAP UE Context Modification with AS re-keying (#40)

### DIFF
--- a/nextgsim-gnb/src/ngap/task.rs
+++ b/nextgsim-gnb/src/ngap/task.rs
@@ -102,6 +102,11 @@ use nextgsim_ngap::procedures::transfer::{
     encode_setup_unsuccessful_transfer, GtpTunnelInfo, ModifyResponseTransferParams,
     SetupResponseTransferParams,
 };
+use nextgsim_ngap::procedures::ue_context_modification::{
+    decode_ue_context_modification_request, encode_ue_context_modification_failure,
+    encode_ue_context_modification_response, UeContextModificationFailureCause,
+    UeContextModificationRequestData,
+};
 use nextgsim_ngap::procedures::ue_context_release::{
     decode_ue_context_release_command, encode_ue_context_release_complete,
     encode_ue_context_release_request, UeContextReleaseCompleteParams,
@@ -691,6 +696,12 @@ impl NgapTask {
                 if ctx.amf_ue_ngap_id.is_none() {
                     ctx.amf_ue_ngap_id = Some(ics_req.amf_ue_ngap_id as i64);
                 }
+                // Store the AMF-provided UE Security Capabilities and UE-AMBR as
+                // the baseline; UE Context Modification may later replace them.
+                ctx.ue_security_capabilities = Some(ics_req.ue_security_capabilities.clone());
+                if let Some(ambr) = ics_req.ue_aggregate_max_bit_rate.clone() {
+                    ctx.ue_ambr = Some(ambr);
+                }
                 // Transition UE state
                 ctx.on_initial_context_setup();
                 info!(
@@ -814,6 +825,139 @@ impl NgapTask {
             Err(e) => {
                 error!("Failed to encode Initial Context Setup Response: {}", e);
             }
+        }
+    }
+
+    /// Handle an inbound UE CONTEXT MODIFICATION REQUEST (TS 38.413 §8.3.4).
+    ///
+    /// Applies any updated UE Security Capabilities and replaced UE-AMBR to the
+    /// stored UE context, and — when a new Security Key IE is present — re-derives
+    /// the AS keys (TS 33.501 §6.9.2) by reusing [`Self::activate_as_security`].
+    /// Replies with a UE CONTEXT MODIFICATION RESPONSE on success, or a UE CONTEXT
+    /// MODIFICATION FAILURE — never an Error Indication — on error. Context state
+    /// is mutated only after every failure precondition has passed, so a failed
+    /// procedure leaves the UE context unchanged (TS 38.413 §8.3.4).
+    ///
+    /// Simulator simplification: the AS re-key is signalled to the UE by reusing
+    /// [`Self::activate_as_security`]'s RRC Security Mode Command (TS 38.331
+    /// §5.3.4), rather than the spec-conformant key-change-on-the-fly carrier — an
+    /// RRCReconfiguration with `masterKeyUpdate` (TS 38.331 §5.3.5.3). This mirrors
+    /// how Initial Context Setup treats the Security Key IE as the KgNB and is
+    /// deliberate: `masterKeyUpdate` is modelled on neither the gNB RRC builder nor
+    /// the UE. The four AS keys are still correctly re-derived from the new KgNB.
+    async fn handle_ue_context_modification_request(
+        &mut self,
+        amf_id: i32,
+        stream: u16,
+        ucm_req: UeContextModificationRequestData,
+    ) {
+        info!(
+            "UE Context Modification Request: amf_ue_ngap_id={}, ran_ue_ngap_id={}, rekey={}",
+            ucm_req.amf_ue_ngap_id,
+            ucm_req.ran_ue_ngap_id,
+            ucm_req.security_key.is_some()
+        );
+
+        // Phase 1 (read-only): locate the UE by RAN-UE-NGAP-ID and resolve the
+        // capabilities a possible AS re-key would use — the request's caps when
+        // present, otherwise the capabilities stored at Initial Context Setup. No
+        // context state is mutated here so that a failed procedure leaves the UE
+        // context unchanged.
+        let (ue_id, stored_caps) = match self
+            .ue_contexts
+            .values()
+            .find(|ctx| ctx.ran_ue_ngap_id == ucm_req.ran_ue_ngap_id as i64)
+        {
+            Some(ctx) => (ctx.ue_id, ctx.ue_security_capabilities.clone()),
+            None => {
+                warn!(
+                    "UE Context Modification for unknown RAN-UE-NGAP-ID {}; replying with UE CONTEXT MODIFICATION FAILURE",
+                    ucm_req.ran_ue_ngap_id
+                );
+                self.send_ue_context_modification_failure(
+                    amf_id,
+                    stream,
+                    ucm_req.amf_ue_ngap_id,
+                    ucm_req.ran_ue_ngap_id,
+                    UeContextModificationFailureCause::RadioNetwork(
+                        RadioNetworkCause::UnknownLocalUeNgapId,
+                    ),
+                )
+                .await;
+                return;
+            }
+        };
+
+        let rekey_caps = ucm_req.ue_security_capabilities.clone().or(stored_caps);
+
+        // Precondition: a Security Key re-key needs the UE Security Capabilities
+        // to select the AS algorithms. Fail BEFORE mutating any context state so
+        // the procedure is atomic.
+        if ucm_req.security_key.is_some() && rekey_caps.is_none() {
+            warn!(
+                "UE Context Modification for UE {ue_id} carried a Security Key but no UE Security Capabilities are available; replying with UE CONTEXT MODIFICATION FAILURE"
+            );
+            self.send_ue_context_modification_failure(
+                amf_id,
+                stream,
+                ucm_req.amf_ue_ngap_id,
+                ucm_req.ran_ue_ngap_id,
+                UeContextModificationFailureCause::Protocol(ProtocolCause::SemanticError),
+            )
+            .await;
+            return;
+        }
+
+        // Phase 2 (commit): every failure precondition has passed — apply the
+        // non-security updates (replaced UE-AMBR and updated UE Security
+        // Capabilities, TS 38.413 §8.3.4.2) to the stored UE context.
+        if let Some(ctx) = self.ue_contexts.values_mut().find(|ctx| ctx.ue_id == ue_id) {
+            if ctx.amf_ue_ngap_id.is_none() {
+                ctx.amf_ue_ngap_id = Some(ucm_req.amf_ue_ngap_id as i64);
+            }
+            if let Some(ambr) = ucm_req.ue_aggregate_max_bit_rate.clone() {
+                ctx.ue_ambr = Some(ambr);
+            }
+            if let Some(caps) = ucm_req.ue_security_capabilities.clone() {
+                ctx.ue_security_capabilities = Some(caps);
+            }
+        }
+
+        // AS re-keying (TS 33.501 §6.9.2): re-derive the AS key set from the new
+        // KgNB. `rekey_caps` is guaranteed present here by the precondition above.
+        if let (Some(new_kgnb), Some(caps)) = (ucm_req.security_key, rekey_caps.as_ref()) {
+            self.activate_as_security(ue_id, new_kgnb, caps).await;
+            info!("AS re-keying completed for UE {ue_id} via UE Context Modification");
+        }
+
+        // Success: UE CONTEXT MODIFICATION RESPONSE.
+        match encode_ue_context_modification_response(
+            ucm_req.amf_ue_ngap_id,
+            ucm_req.ran_ue_ngap_id,
+        ) {
+            Ok(bytes) => {
+                self.send_ngap_ue_associated(amf_id, stream, bytes).await;
+                info!(
+                    "UE Context Modification Response sent for RAN-UE-NGAP-ID {}",
+                    ucm_req.ran_ue_ngap_id
+                );
+            }
+            Err(e) => error!("Failed to encode UE Context Modification Response: {e}"),
+        }
+    }
+
+    /// Encode + send a UE-associated UE CONTEXT MODIFICATION FAILURE.
+    async fn send_ue_context_modification_failure(
+        &self,
+        amf_id: i32,
+        stream: u16,
+        amf_ue_ngap_id: u64,
+        ran_ue_ngap_id: u32,
+        cause: UeContextModificationFailureCause,
+    ) {
+        match encode_ue_context_modification_failure(amf_ue_ngap_id, ran_ue_ngap_id, &cause) {
+            Ok(bytes) => self.send_ngap_ue_associated(amf_id, stream, bytes).await,
+            Err(e) => error!("Failed to encode UE Context Modification Failure: {e}"),
         }
     }
 
@@ -1952,6 +2096,9 @@ impl NgapTask {
                         .await;
                 } else if let Ok(ics_req) = decode_initial_context_setup_request(pdu_bytes) {
                     self.handle_initial_context_setup_request(client_id, stream, ics_req)
+                        .await;
+                } else if let Ok(ucm_req) = decode_ue_context_modification_request(pdu_bytes) {
+                    self.handle_ue_context_modification_request(client_id, stream, ucm_req)
                         .await;
                 } else if let Ok(reset) = decode_ng_reset(pdu_bytes) {
                     self.handle_ng_reset(client_id, stream, reset).await;
@@ -3185,6 +3332,7 @@ mod tests {
     use crate::tasks::{GnbTaskBase, DEFAULT_CHANNEL_CAPACITY};
     use nextgsim_common::config::GnbConfig;
     use nextgsim_common::Plmn;
+    use nextgsim_ngap::procedures::initial_context_setup::UeSecurityCapabilitiesValue;
 
     fn test_config() -> GnbConfig {
         GnbConfig {
@@ -3624,5 +3772,333 @@ mod tests {
         let (code, trigger) = ngap_procedure_code(&pdu);
         assert_eq!(code, ID_ERROR_INDICATION);
         assert_eq!(trigger, TriggeringMessageValue::InitiatingMessage);
+    }
+
+    // ---- UE Context Modification (issue #40) --------------------------------
+
+    /// Procedure code for UE Context Modification (TS 38.413).
+    const ID_UE_CONTEXT_MODIFICATION: u8 = 40;
+
+    /// Seed an NGAP task with a Ready AMF and one UE context; returns the task
+    /// (with `sctp_rx` bound to observe replies) and the UE's RAN-UE-NGAP-ID.
+    fn seed_task_with_ue() -> (
+        NgapTask,
+        tokio::sync::mpsc::Receiver<TaskMessage<SctpMessage>>,
+        i64,
+    ) {
+        let config = test_config();
+        let (task_base, _app_rx, _ngap_rx, _rrc_rx, _gtp_rx, _rls_rx, sctp_rx) =
+            GnbTaskBase::new(config, DEFAULT_CHANNEL_CAPACITY);
+        let mut task = NgapTask::new(task_base);
+        task.create_amf_context(1);
+        if let Some(ctx) = task.find_amf_context_mut(1) {
+            ctx.on_association_up(100, 8, 8);
+            ctx.state = AmfState::Ready;
+        }
+        let ran = task.create_ue_context(10, 1).expect("ue context");
+        (task, sctp_rx, ran)
+    }
+
+    fn caps(nea: u16, nia: u16) -> UeSecurityCapabilitiesValue {
+        UeSecurityCapabilitiesValue {
+            nr_encryption_algorithms: nea,
+            nr_integrity_algorithms: nia,
+            eutra_encryption_algorithms: None,
+            eutra_integrity_algorithms: None,
+        }
+    }
+
+    fn encode_ucm_request(data: &UeContextModificationRequestData) -> Vec<u8> {
+        nextgsim_ngap::procedures::ue_context_modification::encode_ue_context_modification_request(
+            data,
+        )
+        .expect("encode inbound request")
+    }
+
+    /// Decode a UE Context Modification RESPONSE and return the echoed
+    /// (AMF-UE-NGAP-ID, RAN-UE-NGAP-ID).
+    fn response_ids(bytes: &[u8]) -> (u64, u32) {
+        use nextgsim_ngap::codec::generated::{
+            SuccessfulOutcomeValue, UEContextModificationResponseProtocolIEs_EntryValue as RespIe,
+        };
+        match decode_ngap_pdu(bytes).expect("decode response") {
+            NGAP_PDU::SuccessfulOutcome(o) => match o.value {
+                SuccessfulOutcomeValue::Id_UEContextModification(r) => {
+                    let mut amf = None;
+                    let mut ran = None;
+                    for ie in &r.protocol_i_es.0 {
+                        match &ie.value {
+                            RespIe::Id_AMF_UE_NGAP_ID(id) => amf = Some(id.0),
+                            RespIe::Id_RAN_UE_NGAP_ID(id) => ran = Some(id.0),
+                            _ => {}
+                        }
+                    }
+                    (amf.expect("amf id"), ran.expect("ran id"))
+                }
+                other => panic!("expected UEContextModification response, got {other:?}"),
+            },
+            other => panic!("expected SuccessfulOutcome, got {other:?}"),
+        }
+    }
+
+    /// Decode a UE Context Modification FAILURE and return its Cause.
+    fn failure_cause(bytes: &[u8]) -> NgSetupFailureCause {
+        use nextgsim_ngap::codec::generated::{
+            UEContextModificationFailureProtocolIEs_EntryValue as FailIe, UnsuccessfulOutcomeValue,
+        };
+        use nextgsim_ngap::procedures::ue_context_release::parse_cause;
+        match decode_ngap_pdu(bytes).expect("decode failure") {
+            NGAP_PDU::UnsuccessfulOutcome(o) => match o.value {
+                UnsuccessfulOutcomeValue::Id_UEContextModification(f) => {
+                    for ie in &f.protocol_i_es.0 {
+                        if let FailIe::Id_Cause(c) = &ie.value {
+                            return parse_cause(c);
+                        }
+                    }
+                    panic!("no Cause IE in failure");
+                }
+                other => panic!("expected UEContextModification failure, got {other:?}"),
+            },
+            other => panic!("expected UnsuccessfulOutcome, got {other:?}"),
+        }
+    }
+
+    /// A UE CONTEXT MODIFICATION REQUEST carrying a new Security Key re-derives
+    /// the AS keys and the gNB replies with a RESPONSE (not an Error Indication).
+    #[tokio::test]
+    async fn test_ue_context_modification_rekeys_and_responds() {
+        let (mut task, mut sctp_rx, ran) = seed_task_with_ue();
+
+        // Establish a baseline AS security context.
+        task.activate_as_security(10, [0x11u8; 32], &caps(0xC000, 0xC000))
+            .await;
+        let old = task
+            .find_ue_context(10)
+            .unwrap()
+            .as_security
+            .clone()
+            .unwrap();
+
+        // Inbound request with a *new* KgNB and updated capabilities.
+        let data = UeContextModificationRequestData {
+            amf_ue_ngap_id: 555,
+            ran_ue_ngap_id: ran as u32,
+            ue_aggregate_max_bit_rate: None,
+            ue_security_capabilities: Some(caps(0xC000, 0xC000)),
+            security_key: Some([0x22u8; 32]),
+        };
+        let inbound = encode_ucm_request(&data);
+
+        task.handle_ngap_pdu(1, 2, OctetString::from_slice(&inbound))
+            .await;
+
+        // (1) The reply is a UE CONTEXT MODIFICATION RESPONSE, not an Error
+        // Indication, and it echoes the request's AMF/RAN IDs.
+        match sctp_rx.try_recv() {
+            Ok(TaskMessage::Message(SctpMessage::SendMessage { buffer, stream, .. })) => {
+                assert_ne!(stream, 0, "UE-associated reply must not use stream 0");
+                let bytes = buffer.data();
+                match decode_ngap_pdu(bytes).expect("decode reply") {
+                    NGAP_PDU::SuccessfulOutcome(o) => {
+                        assert_eq!(o.procedure_code.0, ID_UE_CONTEXT_MODIFICATION);
+                    }
+                    other => panic!("expected UE Ctx Mod Response, got {other:?}"),
+                }
+                assert_eq!(response_ids(bytes), (555, ran as u32));
+            }
+            other => panic!("expected an outbound SCTP SendMessage, got {other:?}"),
+        }
+
+        // (2) The AS keys were refreshed from the new KgNB.
+        let new = task
+            .find_ue_context(10)
+            .unwrap()
+            .as_security
+            .clone()
+            .unwrap();
+        assert_eq!(new.kgnb, [0x22u8; 32]);
+        assert_ne!(new.k_rrc_enc, old.k_rrc_enc, "AS keys must be re-derived");
+    }
+
+    /// A UE CONTEXT MODIFICATION REQUEST without a Security Key applies the
+    /// replaced UE-AMBR, replies with a RESPONSE, and does not touch AS keys.
+    #[tokio::test]
+    async fn test_ue_context_modification_updates_ambr_without_rekey() {
+        let (mut task, mut sctp_rx, ran) = seed_task_with_ue();
+        task.activate_as_security(10, [0x11u8; 32], &caps(0xC000, 0xC000))
+            .await;
+        let old = task
+            .find_ue_context(10)
+            .unwrap()
+            .as_security
+            .clone()
+            .unwrap();
+
+        let data = UeContextModificationRequestData {
+            amf_ue_ngap_id: 555,
+            ran_ue_ngap_id: ran as u32,
+            ue_aggregate_max_bit_rate: Some(
+                nextgsim_ngap::procedures::initial_context_setup::UeAggregateMaxBitRate {
+                    dl: 300_000_000,
+                    ul: 100_000_000,
+                },
+            ),
+            ue_security_capabilities: None,
+            security_key: None,
+        };
+        let inbound = encode_ucm_request(&data);
+
+        task.handle_ngap_pdu(1, 2, OctetString::from_slice(&inbound))
+            .await;
+
+        match sctp_rx.try_recv() {
+            Ok(TaskMessage::Message(SctpMessage::SendMessage { buffer, .. })) => {
+                let pdu = decode_ngap_pdu(buffer.data()).expect("decode reply");
+                assert!(matches!(pdu, NGAP_PDU::SuccessfulOutcome(_)));
+            }
+            other => panic!("expected a Response, got {other:?}"),
+        }
+
+        let ctx = task.find_ue_context(10).unwrap();
+        let ambr = ctx.ue_ambr.clone().expect("UE-AMBR applied");
+        assert_eq!(ambr.dl, 300_000_000);
+        assert_eq!(ambr.ul, 100_000_000);
+        // No re-key requested → AS keys unchanged.
+        let new = ctx.as_security.clone().unwrap();
+        assert_eq!(new.kgnb, old.kgnb);
+        assert_eq!(new.k_rrc_enc, old.k_rrc_enc);
+    }
+
+    /// A UE CONTEXT MODIFICATION REQUEST for an unknown UE is answered with a
+    /// UE CONTEXT MODIFICATION FAILURE — never an Error Indication.
+    #[tokio::test]
+    async fn test_ue_context_modification_unknown_ue_replies_failure() {
+        let (mut task, mut sctp_rx, _ran) = seed_task_with_ue();
+
+        let data = UeContextModificationRequestData {
+            amf_ue_ngap_id: 555,
+            ran_ue_ngap_id: 9999, // no UE has this RAN-UE-NGAP-ID
+            ue_aggregate_max_bit_rate: None,
+            ue_security_capabilities: None,
+            security_key: Some([0x22u8; 32]),
+        };
+        let inbound = encode_ucm_request(&data);
+
+        task.handle_ngap_pdu(1, 2, OctetString::from_slice(&inbound))
+            .await;
+
+        match sctp_rx.try_recv() {
+            Ok(TaskMessage::Message(SctpMessage::SendMessage { buffer, .. })) => {
+                let bytes = buffer.data();
+                match decode_ngap_pdu(bytes).expect("decode reply") {
+                    NGAP_PDU::UnsuccessfulOutcome(o) => {
+                        assert_eq!(o.procedure_code.0, ID_UE_CONTEXT_MODIFICATION);
+                    }
+                    // An Error Indication would decode as an InitiatingMessage
+                    // (procedure code 9) — explicitly rejected here.
+                    other => panic!("expected UE Ctx Mod Failure, got {other:?}"),
+                }
+                assert_eq!(
+                    failure_cause(bytes),
+                    NgSetupFailureCause::RadioNetwork(RadioNetworkCause::UnknownLocalUeNgapId)
+                );
+            }
+            other => panic!("expected a Failure, got {other:?}"),
+        }
+    }
+
+    /// A Security Key with no resolvable UE Security Capabilities is answered
+    /// with a FAILURE (Protocol/SemanticError), and — crucially — the procedure
+    /// is atomic: a co-carried UE-AMBR is NOT applied and AS keys are untouched.
+    #[tokio::test]
+    async fn test_ue_context_modification_no_caps_rekey_fails_atomically() {
+        // A freshly-created UE context has no stored UE Security Capabilities
+        // (they are set at Initial Context Setup, which we deliberately skip).
+        let (mut task, mut sctp_rx, ran) = seed_task_with_ue();
+        assert!(task
+            .find_ue_context(10)
+            .unwrap()
+            .ue_security_capabilities
+            .is_none());
+
+        let data = UeContextModificationRequestData {
+            amf_ue_ngap_id: 555,
+            ran_ue_ngap_id: ran as u32,
+            // Co-carried UE-AMBR must NOT be committed when the procedure fails.
+            ue_aggregate_max_bit_rate: Some(
+                nextgsim_ngap::procedures::initial_context_setup::UeAggregateMaxBitRate {
+                    dl: 1,
+                    ul: 1,
+                },
+            ),
+            ue_security_capabilities: None,
+            security_key: Some([0x22u8; 32]),
+        };
+        task.handle_ngap_pdu(1, 2, OctetString::from_slice(&encode_ucm_request(&data)))
+            .await;
+
+        match sctp_rx.try_recv() {
+            Ok(TaskMessage::Message(SctpMessage::SendMessage { buffer, .. })) => {
+                let bytes = buffer.data();
+                assert!(matches!(
+                    decode_ngap_pdu(bytes).expect("decode reply"),
+                    NGAP_PDU::UnsuccessfulOutcome(_)
+                ));
+                assert_eq!(
+                    failure_cause(bytes),
+                    NgSetupFailureCause::Protocol(ProtocolCause::SemanticError)
+                );
+            }
+            other => panic!("expected a Failure, got {other:?}"),
+        }
+
+        // Atomicity: nothing was applied on the failed procedure.
+        let ctx = task.find_ue_context(10).unwrap();
+        assert!(
+            ctx.ue_ambr.is_none(),
+            "UE-AMBR must not be applied on failure"
+        );
+        assert!(
+            ctx.as_security.is_none(),
+            "AS keys must be untouched on failure"
+        );
+    }
+
+    /// Updated UE Security Capabilities carried by the request are stored on the
+    /// UE context (TS 38.413 §8.3.4.2).
+    #[tokio::test]
+    async fn test_ue_context_modification_stores_updated_caps() {
+        let (mut task, mut sctp_rx, ran) = seed_task_with_ue();
+
+        let data = UeContextModificationRequestData {
+            amf_ue_ngap_id: 555,
+            ran_ue_ngap_id: ran as u32,
+            ue_aggregate_max_bit_rate: None,
+            ue_security_capabilities: Some(caps(0xA000, 0x8000)),
+            security_key: None,
+        };
+        task.handle_ngap_pdu(1, 2, OctetString::from_slice(&encode_ucm_request(&data)))
+            .await;
+
+        match sctp_rx.try_recv() {
+            Ok(TaskMessage::Message(SctpMessage::SendMessage { buffer, .. })) => {
+                assert!(matches!(
+                    decode_ngap_pdu(buffer.data()).expect("decode reply"),
+                    NGAP_PDU::SuccessfulOutcome(_)
+                ));
+            }
+            other => panic!("expected a Response, got {other:?}"),
+        }
+
+        let stored = task
+            .find_ue_context(10)
+            .unwrap()
+            .ue_security_capabilities
+            .clone()
+            .expect("UE Security Capabilities applied");
+        // Assert the NR fields specifically (parse always fills the E-UTRA
+        // fields, so full-struct equality would be brittle).
+        assert_eq!(stored.nr_encryption_algorithms, 0xA000);
+        assert_eq!(stored.nr_integrity_algorithms, 0x8000);
     }
 }

--- a/nextgsim-gnb/src/ngap/ue_context.rs
+++ b/nextgsim-gnb/src/ngap/ue_context.rs
@@ -10,6 +10,9 @@
 use std::collections::HashMap;
 
 use crate::rrc::transaction::RrcTransactionAllocator;
+use nextgsim_ngap::procedures::initial_context_setup::{
+    UeAggregateMaxBitRate, UeSecurityCapabilitiesValue,
+};
 
 /// UE state within NGAP
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -104,6 +107,12 @@ pub struct NgapUeContext {
     pub requested_nssai: Option<i32>,
     /// AS security context (established at Initial Context Setup).
     pub as_security: Option<AsSecurityContext>,
+    /// UE Aggregate Maximum Bit Rate, as last provided by the AMF (at Initial
+    /// Context Setup and replaced by UE Context Modification, TS 38.413 §8.3.4).
+    pub ue_ambr: Option<UeAggregateMaxBitRate>,
+    /// UE Security Capabilities, as last provided by the AMF (at Initial Context
+    /// Setup and updated by UE Context Modification, TS 38.413 §8.3.4).
+    pub ue_security_capabilities: Option<UeSecurityCapabilitiesValue>,
     /// Per-UE RRC transaction-identifier allocator (TS 38.331 §6.3.2, Wave-6
     /// C4-final) for the DL-DCCH procedures the NGAP task drives:
     /// SecurityModeCommand and RRCReconfiguration. Independent per UE — never a
@@ -124,6 +133,8 @@ impl NgapUeContext {
             pdu_sessions: HashMap::new(),
             requested_nssai: None,
             as_security: None,
+            ue_ambr: None,
+            ue_security_capabilities: None,
             transactions: RrcTransactionAllocator::new(),
         }
     }

--- a/nextgsim-ngap/src/procedures/mod.rs
+++ b/nextgsim-ngap/src/procedures/mod.rs
@@ -20,6 +20,7 @@ pub mod path_switch;
 pub mod pdu_session_resource;
 pub mod ran_configuration_update;
 pub mod transfer;
+pub mod ue_context_modification;
 pub mod ue_context_release;
 
 pub use error_indication::*;
@@ -40,4 +41,5 @@ pub use ntn_support::*;
 pub use paging::*;
 pub use pdu_session_resource::*;
 pub use ran_configuration_update::*;
+pub use ue_context_modification::*;
 pub use ue_context_release::*;

--- a/nextgsim-ngap/src/procedures/ue_context_modification.rs
+++ b/nextgsim-ngap/src/procedures/ue_context_modification.rs
@@ -1,0 +1,585 @@
+//! UE Context Modification Procedure
+//!
+//! Implements the UE Context Modification procedure defined in 3GPP TS 38.413
+//! Section 8.3.4. This is a mandatory class-1 procedure by which the AMF modifies
+//! an established UE context in the NG-RAN node. It can carry:
+//!
+//! - a new **Security Key** (KgNB) IE that triggers AS re-keying (TS 33.501
+//!   Section 6.9.2),
+//! - updated **UE Security Capabilities**, and
+//! - a replaced **UE Aggregate Maximum Bit Rate** (UE-AMBR).
+//!
+//! The NG-RAN node answers with a UE CONTEXT MODIFICATION RESPONSE
+//! (SuccessfulOutcome) on success, or a UE CONTEXT MODIFICATION FAILURE
+//! (UnsuccessfulOutcome) carrying a Cause on error — never with an Error
+//! Indication.
+//!
+//! Only AMF-UE-NGAP-ID and RAN-UE-NGAP-ID are mandatory on the request
+//! (TS 38.413 Section 9.2.2.7); the Security Key, UE Security Capabilities and
+//! UE-AMBR are all optional and are surfaced as `Option`s below.
+
+use crate::codec::generated::*;
+use crate::codec::{decode_ngap_pdu, encode_ngap_pdu, NgapCodecError};
+use crate::procedures::initial_context_setup::{
+    UeAggregateMaxBitRate, UeSecurityCapabilitiesValue,
+};
+use crate::procedures::ng_setup::NgSetupFailureCause;
+use crate::procedures::ue_context_release::build_cause;
+use bitvec::prelude::*;
+use thiserror::Error;
+
+/// Cause values for a UE Context Modification Failure. Reuses the shared typed
+/// cause hierarchy (see [`NgSetupFailureCause`]).
+pub type UeContextModificationFailureCause = NgSetupFailureCause;
+
+/// Errors that can occur while handling UE Context Modification messages.
+#[derive(Debug, Error)]
+pub enum UeContextModificationError {
+    /// Underlying APER codec error.
+    #[error("Codec error: {0}")]
+    CodecError(#[from] NgapCodecError),
+    /// The PDU was not the expected envelope / procedure.
+    #[error("Invalid message type: expected {expected}, got {actual}")]
+    InvalidMessageType {
+        /// What was expected.
+        expected: String,
+        /// What was actually decoded.
+        actual: String,
+    },
+    /// A mandatory IE was absent.
+    #[error("Missing mandatory IE: {0}")]
+    MissingMandatoryIe(String),
+}
+
+// ============================================================================
+// UE Context Modification Request (decoded)
+// ============================================================================
+
+/// Parsed UE Context Modification Request data.
+#[derive(Debug, Clone)]
+pub struct UeContextModificationRequestData {
+    /// AMF UE NGAP ID (mandatory).
+    pub amf_ue_ngap_id: u64,
+    /// RAN UE NGAP ID (mandatory).
+    pub ran_ue_ngap_id: u32,
+    /// Replaced UE Aggregate Maximum Bit Rate (optional).
+    pub ue_aggregate_max_bit_rate: Option<UeAggregateMaxBitRate>,
+    /// Updated UE Security Capabilities (optional).
+    pub ue_security_capabilities: Option<UeSecurityCapabilitiesValue>,
+    /// New NR key (KgNB), BIT STRING(256) rendered as 32 bytes (optional).
+    /// When present, triggers AS re-keying.
+    pub security_key: Option<[u8; 32]>,
+}
+
+/// Parse a UE Context Modification Request from an already-decoded NGAP PDU.
+pub fn parse_ue_context_modification_request(
+    pdu: &NGAP_PDU,
+) -> Result<UeContextModificationRequestData, UeContextModificationError> {
+    let initiating_message = match pdu {
+        NGAP_PDU::InitiatingMessage(msg) => msg,
+        _ => {
+            return Err(UeContextModificationError::InvalidMessageType {
+                expected: "InitiatingMessage".to_string(),
+                actual: format!("{pdu:?}"),
+            })
+        }
+    };
+
+    let request = match &initiating_message.value {
+        InitiatingMessageValue::Id_UEContextModification(req) => req,
+        _ => {
+            return Err(UeContextModificationError::InvalidMessageType {
+                expected: "UEContextModificationRequest".to_string(),
+                actual: format!("{:?}", initiating_message.value),
+            })
+        }
+    };
+
+    let mut amf_ue_ngap_id: Option<u64> = None;
+    let mut ran_ue_ngap_id: Option<u32> = None;
+    let mut ue_aggregate_max_bit_rate: Option<UeAggregateMaxBitRate> = None;
+    let mut ue_security_capabilities: Option<UeSecurityCapabilitiesValue> = None;
+    let mut security_key: Option<[u8; 32]> = None;
+
+    for ie in &request.protocol_i_es.0 {
+        match &ie.value {
+            UEContextModificationRequestProtocolIEs_EntryValue::Id_AMF_UE_NGAP_ID(id) => {
+                amf_ue_ngap_id = Some(id.0);
+            }
+            UEContextModificationRequestProtocolIEs_EntryValue::Id_RAN_UE_NGAP_ID(id) => {
+                ran_ue_ngap_id = Some(id.0);
+            }
+            UEContextModificationRequestProtocolIEs_EntryValue::Id_UEAggregateMaximumBitRate(
+                rate,
+            ) => {
+                ue_aggregate_max_bit_rate = Some(parse_ue_aggregate_max_bit_rate(rate));
+            }
+            UEContextModificationRequestProtocolIEs_EntryValue::Id_UESecurityCapabilities(caps) => {
+                ue_security_capabilities = Some(parse_ue_security_capabilities(caps));
+            }
+            UEContextModificationRequestProtocolIEs_EntryValue::Id_SecurityKey(key) => {
+                security_key = Some(parse_security_key(key));
+            }
+            // Other IEs (New AMF-UE-NGAP-ID, New GUAMI, IndexToRFSP,
+            // EmergencyFallbackIndicator, ...) are not modelled here.
+            _ => {}
+        }
+    }
+
+    Ok(UeContextModificationRequestData {
+        amf_ue_ngap_id: amf_ue_ngap_id.ok_or_else(|| {
+            UeContextModificationError::MissingMandatoryIe("AMF-UE-NGAP-ID".to_string())
+        })?,
+        ran_ue_ngap_id: ran_ue_ngap_id.ok_or_else(|| {
+            UeContextModificationError::MissingMandatoryIe("RAN-UE-NGAP-ID".to_string())
+        })?,
+        ue_aggregate_max_bit_rate,
+        ue_security_capabilities,
+        security_key,
+    })
+}
+
+/// Decode + parse a UE Context Modification Request from bytes.
+pub fn decode_ue_context_modification_request(
+    bytes: &[u8],
+) -> Result<UeContextModificationRequestData, UeContextModificationError> {
+    let pdu = decode_ngap_pdu(bytes)?;
+    parse_ue_context_modification_request(&pdu)
+}
+
+// ---- IE decode helpers ----------------------------------------------------
+// These mirror the private helpers in `initial_context_setup.rs`. They are kept
+// private to this module (rather than importing the ICS versions) so that making
+// them re-exportable does not introduce `ambiguous_glob_reexports` across the
+// procedure modules.
+
+fn parse_ue_aggregate_max_bit_rate(rate: &UEAggregateMaximumBitRate) -> UeAggregateMaxBitRate {
+    UeAggregateMaxBitRate {
+        dl: rate.ue_aggregate_maximum_bit_rate_dl.0,
+        ul: rate.ue_aggregate_maximum_bit_rate_ul.0,
+    }
+}
+
+fn parse_ue_security_capabilities(caps: &UESecurityCapabilities) -> UeSecurityCapabilitiesValue {
+    UeSecurityCapabilitiesValue {
+        nr_encryption_algorithms: parse_16bit_bitvec(&caps.n_rencryption_algorithms.0),
+        nr_integrity_algorithms: parse_16bit_bitvec(&caps.n_rintegrity_protection_algorithms.0),
+        eutra_encryption_algorithms: Some(parse_16bit_bitvec(&caps.eutr_aencryption_algorithms.0)),
+        eutra_integrity_algorithms: Some(parse_16bit_bitvec(
+            &caps.eutr_aintegrity_protection_algorithms.0,
+        )),
+    }
+}
+
+fn parse_16bit_bitvec(bv: &BitVec<u8, Msb0>) -> u16 {
+    if bv.len() >= 16 {
+        let mut value: u16 = 0;
+        for (i, bit) in bv.iter().take(16).enumerate() {
+            if *bit {
+                value |= 1 << (15 - i);
+            }
+        }
+        value
+    } else {
+        0
+    }
+}
+
+fn parse_security_key(key: &SecurityKey) -> [u8; 32] {
+    let mut result = [0u8; 32];
+    let raw = key.0.as_raw_slice();
+    let len = raw.len().min(32);
+    result[..len].copy_from_slice(&raw[..len]);
+    result
+}
+
+/// Pack a `u16` into a 16-bit, MSB-first BIT STRING (the wire form for the
+/// per-family algorithm bitmaps).
+fn build_16bit_bitvec_from_u16(value: u16) -> BitVec<u8, Msb0> {
+    let mut bv: BitVec<u8, Msb0> = BitVec::with_capacity(16);
+    for i in (0..16).rev() {
+        bv.push((value >> i) & 1 == 1);
+    }
+    bv
+}
+
+// ============================================================================
+// UE Context Modification Request (encode) — the AMF/peer side. The gNB is the
+// receiver in production, but a full codec (build + parse) is provided for
+// symmetry with the other procedures and for interop/testing.
+// ============================================================================
+
+/// Build a UE Context Modification Request PDU from parsed request data.
+pub fn build_ue_context_modification_request(
+    data: &UeContextModificationRequestData,
+) -> Result<NGAP_PDU, UeContextModificationError> {
+    let mut protocol_ies = vec![
+        UEContextModificationRequestProtocolIEs_Entry {
+            id: ProtocolIE_ID(ID_AMF_UE_NGAP_ID),
+            criticality: Criticality(Criticality::REJECT),
+            value: UEContextModificationRequestProtocolIEs_EntryValue::Id_AMF_UE_NGAP_ID(
+                AMF_UE_NGAP_ID(data.amf_ue_ngap_id),
+            ),
+        },
+        UEContextModificationRequestProtocolIEs_Entry {
+            id: ProtocolIE_ID(ID_RAN_UE_NGAP_ID),
+            criticality: Criticality(Criticality::REJECT),
+            value: UEContextModificationRequestProtocolIEs_EntryValue::Id_RAN_UE_NGAP_ID(
+                RAN_UE_NGAP_ID(data.ran_ue_ngap_id),
+            ),
+        },
+    ];
+
+    if let Some(ambr) = &data.ue_aggregate_max_bit_rate {
+        protocol_ies.push(UEContextModificationRequestProtocolIEs_Entry {
+            id: ProtocolIE_ID(ID_UE_AGGREGATE_MAXIMUM_BIT_RATE),
+            criticality: Criticality(Criticality::IGNORE),
+            value: UEContextModificationRequestProtocolIEs_EntryValue::Id_UEAggregateMaximumBitRate(
+                UEAggregateMaximumBitRate {
+                    ue_aggregate_maximum_bit_rate_dl: BitRate(ambr.dl),
+                    ue_aggregate_maximum_bit_rate_ul: BitRate(ambr.ul),
+                    ie_extensions: None,
+                },
+            ),
+        });
+    }
+
+    if let Some(caps) = &data.ue_security_capabilities {
+        protocol_ies.push(UEContextModificationRequestProtocolIEs_Entry {
+            id: ProtocolIE_ID(ID_UE_SECURITY_CAPABILITIES),
+            criticality: Criticality(Criticality::REJECT),
+            value: UEContextModificationRequestProtocolIEs_EntryValue::Id_UESecurityCapabilities(
+                UESecurityCapabilities {
+                    n_rencryption_algorithms: NRencryptionAlgorithms(build_16bit_bitvec_from_u16(
+                        caps.nr_encryption_algorithms,
+                    )),
+                    n_rintegrity_protection_algorithms: NRintegrityProtectionAlgorithms(
+                        build_16bit_bitvec_from_u16(caps.nr_integrity_algorithms),
+                    ),
+                    eutr_aencryption_algorithms: EUTRAencryptionAlgorithms(
+                        build_16bit_bitvec_from_u16(caps.eutra_encryption_algorithms.unwrap_or(0)),
+                    ),
+                    eutr_aintegrity_protection_algorithms: EUTRAintegrityProtectionAlgorithms(
+                        build_16bit_bitvec_from_u16(caps.eutra_integrity_algorithms.unwrap_or(0)),
+                    ),
+                    ie_extensions: None,
+                },
+            ),
+        });
+    }
+
+    if let Some(key) = &data.security_key {
+        protocol_ies.push(UEContextModificationRequestProtocolIEs_Entry {
+            id: ProtocolIE_ID(ID_SECURITY_KEY),
+            criticality: Criticality(Criticality::REJECT),
+            value: UEContextModificationRequestProtocolIEs_EntryValue::Id_SecurityKey(SecurityKey(
+                BitVec::<u8, Msb0>::from_slice(key),
+            )),
+        });
+    }
+
+    let request = UEContextModificationRequest {
+        protocol_i_es: UEContextModificationRequestProtocolIEs(protocol_ies),
+    };
+
+    let initiating_message = InitiatingMessage {
+        procedure_code: ProcedureCode(ID_UE_CONTEXT_MODIFICATION),
+        criticality: Criticality(Criticality::REJECT),
+        value: InitiatingMessageValue::Id_UEContextModification(request),
+    };
+
+    Ok(NGAP_PDU::InitiatingMessage(initiating_message))
+}
+
+/// Build + encode a UE Context Modification Request to bytes.
+pub fn encode_ue_context_modification_request(
+    data: &UeContextModificationRequestData,
+) -> Result<Vec<u8>, UeContextModificationError> {
+    let pdu = build_ue_context_modification_request(data)?;
+    Ok(encode_ngap_pdu(&pdu)?)
+}
+
+// ============================================================================
+// UE Context Modification Response (SuccessfulOutcome)
+// ============================================================================
+
+/// Build a UE Context Modification Response PDU carrying the mandatory
+/// AMF-UE-NGAP-ID and RAN-UE-NGAP-ID.
+pub fn build_ue_context_modification_response(
+    amf_ue_id: u64,
+    ran_ue_id: u32,
+) -> Result<NGAP_PDU, UeContextModificationError> {
+    let protocol_ies = vec![
+        UEContextModificationResponseProtocolIEs_Entry {
+            id: ProtocolIE_ID(ID_AMF_UE_NGAP_ID),
+            criticality: Criticality(Criticality::IGNORE),
+            value: UEContextModificationResponseProtocolIEs_EntryValue::Id_AMF_UE_NGAP_ID(
+                AMF_UE_NGAP_ID(amf_ue_id),
+            ),
+        },
+        UEContextModificationResponseProtocolIEs_Entry {
+            id: ProtocolIE_ID(ID_RAN_UE_NGAP_ID),
+            criticality: Criticality(Criticality::IGNORE),
+            value: UEContextModificationResponseProtocolIEs_EntryValue::Id_RAN_UE_NGAP_ID(
+                RAN_UE_NGAP_ID(ran_ue_id),
+            ),
+        },
+    ];
+
+    let response = UEContextModificationResponse {
+        protocol_i_es: UEContextModificationResponseProtocolIEs(protocol_ies),
+    };
+
+    let successful_outcome = SuccessfulOutcome {
+        procedure_code: ProcedureCode(ID_UE_CONTEXT_MODIFICATION),
+        criticality: Criticality(Criticality::REJECT),
+        value: SuccessfulOutcomeValue::Id_UEContextModification(response),
+    };
+
+    Ok(NGAP_PDU::SuccessfulOutcome(successful_outcome))
+}
+
+/// Build + encode a UE Context Modification Response to bytes.
+pub fn encode_ue_context_modification_response(
+    amf_ue_id: u64,
+    ran_ue_id: u32,
+) -> Result<Vec<u8>, UeContextModificationError> {
+    let pdu = build_ue_context_modification_response(amf_ue_id, ran_ue_id)?;
+    Ok(encode_ngap_pdu(&pdu)?)
+}
+
+// ============================================================================
+// UE Context Modification Failure (UnsuccessfulOutcome)
+// ============================================================================
+
+/// Build a UE Context Modification Failure PDU carrying AMF-UE-NGAP-ID,
+/// RAN-UE-NGAP-ID and a Cause.
+pub fn build_ue_context_modification_failure(
+    amf_ue_id: u64,
+    ran_ue_id: u32,
+    cause: &UeContextModificationFailureCause,
+) -> Result<NGAP_PDU, UeContextModificationError> {
+    let protocol_ies = vec![
+        UEContextModificationFailureProtocolIEs_Entry {
+            id: ProtocolIE_ID(ID_AMF_UE_NGAP_ID),
+            criticality: Criticality(Criticality::IGNORE),
+            value: UEContextModificationFailureProtocolIEs_EntryValue::Id_AMF_UE_NGAP_ID(
+                AMF_UE_NGAP_ID(amf_ue_id),
+            ),
+        },
+        UEContextModificationFailureProtocolIEs_Entry {
+            id: ProtocolIE_ID(ID_RAN_UE_NGAP_ID),
+            criticality: Criticality(Criticality::IGNORE),
+            value: UEContextModificationFailureProtocolIEs_EntryValue::Id_RAN_UE_NGAP_ID(
+                RAN_UE_NGAP_ID(ran_ue_id),
+            ),
+        },
+        UEContextModificationFailureProtocolIEs_Entry {
+            id: ProtocolIE_ID(ID_CAUSE),
+            criticality: Criticality(Criticality::IGNORE),
+            value: UEContextModificationFailureProtocolIEs_EntryValue::Id_Cause(build_cause(cause)),
+        },
+    ];
+
+    let failure = UEContextModificationFailure {
+        protocol_i_es: UEContextModificationFailureProtocolIEs(protocol_ies),
+    };
+
+    let unsuccessful_outcome = UnsuccessfulOutcome {
+        procedure_code: ProcedureCode(ID_UE_CONTEXT_MODIFICATION),
+        criticality: Criticality(Criticality::REJECT),
+        value: UnsuccessfulOutcomeValue::Id_UEContextModification(failure),
+    };
+
+    Ok(NGAP_PDU::UnsuccessfulOutcome(unsuccessful_outcome))
+}
+
+/// Build + encode a UE Context Modification Failure to bytes.
+pub fn encode_ue_context_modification_failure(
+    amf_ue_id: u64,
+    ran_ue_id: u32,
+    cause: &UeContextModificationFailureCause,
+) -> Result<Vec<u8>, UeContextModificationError> {
+    let pdu = build_ue_context_modification_failure(amf_ue_id, ran_ue_id, cause)?;
+    Ok(encode_ngap_pdu(&pdu)?)
+}
+
+// ============================================================================
+// Type predicates
+// ============================================================================
+
+/// Returns `true` if the PDU is a UE Context Modification Request.
+pub fn is_ue_context_modification_request(pdu: &NGAP_PDU) -> bool {
+    matches!(
+        pdu,
+        NGAP_PDU::InitiatingMessage(msg)
+            if matches!(msg.value, InitiatingMessageValue::Id_UEContextModification(_))
+    )
+}
+
+/// Returns `true` if the PDU is a UE Context Modification Response.
+pub fn is_ue_context_modification_response(pdu: &NGAP_PDU) -> bool {
+    matches!(
+        pdu,
+        NGAP_PDU::SuccessfulOutcome(msg)
+            if matches!(msg.value, SuccessfulOutcomeValue::Id_UEContextModification(_))
+    )
+}
+
+/// Returns `true` if the PDU is a UE Context Modification Failure.
+pub fn is_ue_context_modification_failure(pdu: &NGAP_PDU) -> bool {
+    matches!(
+        pdu,
+        NGAP_PDU::UnsuccessfulOutcome(msg)
+            if matches!(msg.value, UnsuccessfulOutcomeValue::Id_UEContextModification(_))
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::procedures::ng_setup::RadioNetworkCause;
+
+    /// Build a UE Context Modification Request PDU with the mandatory IDs plus an
+    /// optional Security Key, UE Security Capabilities and UE-AMBR, via the
+    /// public builder.
+    fn build_test_request_pdu(
+        amf_ue_ngap_id: u64,
+        ran_ue_ngap_id: u32,
+        security_key: Option<[u8; 32]>,
+        caps: Option<(u16, u16)>,
+        ambr: Option<(u64, u64)>,
+    ) -> NGAP_PDU {
+        let data = UeContextModificationRequestData {
+            amf_ue_ngap_id,
+            ran_ue_ngap_id,
+            ue_aggregate_max_bit_rate: ambr.map(|(dl, ul)| UeAggregateMaxBitRate { dl, ul }),
+            ue_security_capabilities: caps.map(|(nea, nia)| UeSecurityCapabilitiesValue {
+                nr_encryption_algorithms: nea,
+                nr_integrity_algorithms: nia,
+                eutra_encryption_algorithms: Some(0),
+                eutra_integrity_algorithms: Some(0),
+            }),
+            security_key,
+        };
+        build_ue_context_modification_request(&data).expect("build request")
+    }
+
+    #[test]
+    fn request_roundtrip_carries_all_ies() {
+        let key: [u8; 32] = core::array::from_fn(|i| i as u8 + 1);
+        let pdu = build_test_request_pdu(
+            12345,
+            7,
+            Some(key),
+            Some((0xE000, 0xE000)),
+            Some((1000, 2000)),
+        );
+
+        let encoded = encode_ngap_pdu(&pdu).expect("encode request");
+        assert!(!encoded.is_empty());
+
+        let parsed = decode_ue_context_modification_request(&encoded).expect("decode request");
+        assert_eq!(parsed.amf_ue_ngap_id, 12345);
+        assert_eq!(parsed.ran_ue_ngap_id, 7);
+        assert_eq!(parsed.security_key, Some(key));
+        let caps = parsed.ue_security_capabilities.expect("caps present");
+        assert_eq!(caps.nr_encryption_algorithms, 0xE000);
+        assert_eq!(caps.nr_integrity_algorithms, 0xE000);
+        let ambr = parsed.ue_aggregate_max_bit_rate.expect("ambr present");
+        assert_eq!(ambr.dl, 1000);
+        assert_eq!(ambr.ul, 2000);
+    }
+
+    #[test]
+    fn request_roundtrip_minimal_ids_only() {
+        let pdu = build_test_request_pdu(1, 2, None, None, None);
+        let encoded = encode_ngap_pdu(&pdu).expect("encode request");
+        let parsed = decode_ue_context_modification_request(&encoded).expect("decode request");
+        assert_eq!(parsed.amf_ue_ngap_id, 1);
+        assert_eq!(parsed.ran_ue_ngap_id, 2);
+        assert!(parsed.security_key.is_none());
+        assert!(parsed.ue_security_capabilities.is_none());
+        assert!(parsed.ue_aggregate_max_bit_rate.is_none());
+    }
+
+    #[test]
+    fn request_aper_byte_level_roundtrip() {
+        let key: [u8; 32] = core::array::from_fn(|i| (0xA0 + i) as u8);
+        let pdu = build_test_request_pdu(9, 3, Some(key), Some((0xC000, 0xC000)), None);
+        let encoded = encode_ngap_pdu(&pdu).expect("encode");
+        let decoded = decode_ngap_pdu(&encoded).expect("decode");
+        let re_encoded = encode_ngap_pdu(&decoded).expect("re-encode");
+        assert_eq!(
+            encoded, re_encoded,
+            "APER re-encoding must be deterministic"
+        );
+    }
+
+    #[test]
+    fn request_missing_mandatory_ie_errors() {
+        // A request with only RAN-UE-NGAP-ID (no AMF-UE-NGAP-ID) must fail to parse.
+        let pdu = NGAP_PDU::InitiatingMessage(InitiatingMessage {
+            procedure_code: ProcedureCode(ID_UE_CONTEXT_MODIFICATION),
+            criticality: Criticality(Criticality::REJECT),
+            value: InitiatingMessageValue::Id_UEContextModification(UEContextModificationRequest {
+                protocol_i_es: UEContextModificationRequestProtocolIEs(vec![
+                    UEContextModificationRequestProtocolIEs_Entry {
+                        id: ProtocolIE_ID(ID_RAN_UE_NGAP_ID),
+                        criticality: Criticality(Criticality::REJECT),
+                        value:
+                            UEContextModificationRequestProtocolIEs_EntryValue::Id_RAN_UE_NGAP_ID(
+                                RAN_UE_NGAP_ID(2),
+                            ),
+                    },
+                ]),
+            }),
+        });
+        let encoded = encode_ngap_pdu(&pdu).expect("encode");
+        let err = decode_ue_context_modification_request(&encoded).unwrap_err();
+        assert!(matches!(
+            err,
+            UeContextModificationError::MissingMandatoryIe(_)
+        ));
+    }
+
+    #[test]
+    fn response_roundtrip() {
+        let bytes = encode_ue_context_modification_response(42, 5).expect("encode response");
+        let pdu = decode_ngap_pdu(&bytes).expect("decode response");
+        assert!(is_ue_context_modification_response(&pdu));
+        match pdu {
+            NGAP_PDU::SuccessfulOutcome(o) => {
+                assert_eq!(o.procedure_code.0, ID_UE_CONTEXT_MODIFICATION);
+            }
+            other => panic!("expected SuccessfulOutcome, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn failure_roundtrip_carries_cause() {
+        let cause = UeContextModificationFailureCause::RadioNetwork(
+            RadioNetworkCause::UnknownLocalUeNgapId,
+        );
+        let bytes = encode_ue_context_modification_failure(42, 5, &cause).expect("encode failure");
+        let pdu = decode_ngap_pdu(&bytes).expect("decode failure");
+        assert!(is_ue_context_modification_failure(&pdu));
+        match pdu {
+            NGAP_PDU::UnsuccessfulOutcome(o) => {
+                assert_eq!(o.procedure_code.0, ID_UE_CONTEXT_MODIFICATION);
+                // Cause IE must be present.
+                let has_cause = o.value.clone();
+                match has_cause {
+                    UnsuccessfulOutcomeValue::Id_UEContextModification(f) => {
+                        assert!(f.protocol_i_es.0.iter().any(|ie| matches!(
+                            ie.value,
+                            UEContextModificationFailureProtocolIEs_EntryValue::Id_Cause(_)
+                        )));
+                    }
+                    other => panic!("expected UEContextModification failure, got {other:?}"),
+                }
+            }
+            other => panic!("expected UnsuccessfulOutcome, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the mandatory class-1 **NGAP UE Context Modification** procedure (TS 38.413 §8.3.4; TS 33.501 §6.9.2). Previously the gNB answered an inbound UE CONTEXT MODIFICATION REQUEST with an NGAP Error Indication because no decode path or handler existed, so AMF-initiated AS re-keying, updated UE Security Capabilities and a replaced UE-AMBR could not be honoured.

## Changes

- **`nextgsim-ngap` — new `procedures/ue_context_modification` module**: build/parse the Request and encode the Response and Failure over the generated APER codec, reusing the shared `build_cause`/`parse_cause` helpers; type predicates; full codec round-trip test suite.
- **`nextgsim-gnb` — dispatch branch + `handle_ue_context_modification_request`**: applies the replaced UE-AMBR and updated UE Security Capabilities to the stored UE context and, when a Security Key IE is present, re-derives the AS keys via the existing `activate_as_security`. Replies with a **RESPONSE** on success or a **FAILURE** on error (unknown UE → `RadioNetwork(UnknownLocalUeNgapId)`; Security Key with no resolvable capabilities → `Protocol(SemanticError)`) — **never an Error Indication**.
- Persist `ue_ambr` and `ue_security_capabilities` on `NgapUeContext`, baseline set at Initial Context Setup.
- **Atomic handler**: context state is mutated only after every failure precondition passes, so a failed procedure leaves the UE context unchanged.

## Testing

- 6 codec round-trip unit tests (Request with all IEs / minimal / byte-level determinism / missing-mandatory-IE error; Response; Failure with Cause).
- 5 gNB integration tests driving an inbound request through `handle_ngap_pdu`: re-key + RESPONSE with echoed IDs and refreshed AS keys; UE-AMBR applied without re-key; unknown-UE → FAILURE (asserted Cause); Security-Key-without-caps → FAILURE atomicity (no state applied); updated capabilities stored.
- Gate green: `cargo fmt --all --check`, `cargo clippy --workspace` (0 warnings), `cargo test --workspace` (3290 passed / 0 failed).

## Note on scope

The AS re-key is signalled to the UE by reusing the RRC Security Mode Command rather than the spec-conformant key-change-on-the-fly carrier (an RRCReconfiguration with `masterKeyUpdate`, TS 38.331 §5.3.5.3). This matches how Initial Context Setup treats the Security Key IE as the KgNB and is deliberate: `masterKeyUpdate` is modelled on neither the gNB RRC builder nor the UE. The four AS keys are still correctly re-derived from the new KgNB. Documented in the handler.

Closes #40
