### PR TITLE
refactor(gnb): feature-gate the 6G/AI crates as optional deps (#24)

### DIFF
--- a/nextgsim-gnb/Cargo.toml
+++ b/nextgsim-gnb/Cargo.toml
@@ -16,6 +16,19 @@ workspace = true
 # 132). Only effective on Linux; requires libsctp (`-lsctp`) at link time.
 kernel-sctp = ["nextgsim-sctp/kernel-sctp"]
 
+# Umbrella feature enabling all six optional 6G / AI-native research crates at
+# once. Off by default, so `cargo build -p nextgsim-gnb` yields a lean 5G gNB and
+# `cargo build -p nextgsim-gnb --features 6g` yields the full build. There is no
+# frozen 3GPP Rel-20/6G Stage-3 spec behind these crates.
+6g = [
+    "nextgsim-she",
+    "nextgsim-nwdaf",
+    "nextgsim-nkef",
+    "nextgsim-isac",
+    "nextgsim-agent",
+    "nextgsim-fl",
+]
+
 [[bin]]
 name = "nr-gnb"
 path = "src/main.rs"
@@ -34,13 +47,14 @@ nextgsim-rlc.workspace = true
 nextgsim-gtp.workspace = true
 nextgsim-sctp.workspace = true
 
-# 6G AI-native network function crates
-nextgsim-she.workspace = true
-nextgsim-nwdaf.workspace = true
-nextgsim-nkef.workspace = true
-nextgsim-isac.workspace = true
-nextgsim-agent.workspace = true
-nextgsim-fl.workspace = true
+# 6G AI-native network function crates (optional, off by default — gated behind
+# the `6g` umbrella feature above / the per-crate `nextgsim-*` features).
+nextgsim-she = { workspace = true, optional = true }
+nextgsim-nwdaf = { workspace = true, optional = true }
+nextgsim-nkef = { workspace = true, optional = true }
+nextgsim-isac = { workspace = true, optional = true }
+nextgsim-agent = { workspace = true, optional = true }
+nextgsim-fl = { workspace = true, optional = true }
 
 log.workspace = true
 tracing-log.workspace = true

--- a/nextgsim-gnb/src/lib.rs
+++ b/nextgsim-gnb/src/lib.rs
@@ -80,12 +80,19 @@ pub mod rrc;
 pub mod sctp;
 pub mod tasks;
 
-// 6G AI-native network function modules
+// 6G AI-native network function modules (optional; each gated behind its crate
+// feature so a lean `cargo build -p nextgsim-gnb` excludes them).
+#[cfg(feature = "nextgsim-agent")]
 pub mod agent;
+#[cfg(feature = "nextgsim-fl")]
 pub mod fl;
+#[cfg(feature = "nextgsim-isac")]
 pub mod isac;
+#[cfg(feature = "nextgsim-nkef")]
 pub mod nkef;
+#[cfg(feature = "nextgsim-nwdaf")]
 pub mod nwdaf;
+#[cfg(feature = "nextgsim-she")]
 pub mod she;
 
 // Rel-18 5G-Advanced modules
@@ -135,12 +142,19 @@ pub use tasks::{
 // Re-export lifecycle management types
 pub use tasks::{TaskError, TaskId, TaskInfo, TaskManager, TaskState, DEFAULT_SHUTDOWN_TIMEOUT_MS};
 
-// Re-export 6G AI-native network function types
+// Re-export 6G AI-native network function types (feature-gated to match the
+// optional module declarations above).
+#[cfg(feature = "nextgsim-agent")]
 pub use agent::AgentTask;
+#[cfg(feature = "nextgsim-fl")]
 pub use fl::FlAggregatorTask;
+#[cfg(feature = "nextgsim-isac")]
 pub use isac::IsacTask;
+#[cfg(feature = "nextgsim-nkef")]
 pub use nkef::NkefTask;
+#[cfg(feature = "nextgsim-nwdaf")]
 pub use nwdaf::NwdafTask;
+#[cfg(feature = "nextgsim-she")]
 pub use she::SheTask;
 
 // Re-export Rel-18 5G-Advanced types

--- a/nextgsim-gnb/src/main.rs
+++ b/nextgsim-gnb/src/main.rs
@@ -25,10 +25,23 @@ use tokio::sync::watch;
 use tracing::{error, info, warn};
 
 use nextgsim_gnb::{
-    load_and_validate_gnb_config, AgentTask, AppTask, EnergyTask, FlAggregatorTask, GtpTask,
-    IsacTask, NgapTask, NkefTask, NwdafTask, RlsTask, RrcTask, SctpMessage, SctpTask, SheTask,
-    Task, TaskError, TaskManager, TaskMessage, DEFAULT_CHANNEL_CAPACITY, NGAP_PPID,
+    load_and_validate_gnb_config, AppTask, EnergyTask, GtpTask, NgapTask, RlsTask, RrcTask,
+    SctpMessage, SctpTask, Task, TaskError, TaskManager, TaskMessage, DEFAULT_CHANNEL_CAPACITY,
+    NGAP_PPID,
 };
+// Optional 6G AI-native task types — only present when their crate feature is on.
+#[cfg(feature = "nextgsim-agent")]
+use nextgsim_gnb::AgentTask;
+#[cfg(feature = "nextgsim-fl")]
+use nextgsim_gnb::FlAggregatorTask;
+#[cfg(feature = "nextgsim-isac")]
+use nextgsim_gnb::IsacTask;
+#[cfg(feature = "nextgsim-nkef")]
+use nextgsim_gnb::NkefTask;
+#[cfg(feature = "nextgsim-nwdaf")]
+use nextgsim_gnb::NwdafTask;
+#[cfg(feature = "nextgsim-she")]
+use nextgsim_gnb::SheTask;
 
 /// nextgsim gNB - 5G gNodeB Simulator
 #[derive(Parser, Debug)]
@@ -189,69 +202,88 @@ impl GnbApp {
             info!("Energy task spawned");
         }
 
-        // Spawn 6G AI-native network function tasks (Rel-20)
-        let any_6g = task_base.config.she_enabled
-            || task_base.config.nwdaf_enabled
-            || task_base.config.nkef_enabled
-            || task_base.config.isac_enabled
-            || task_base.config.agent_enabled
-            || task_base.config.federated_learning_enabled;
+        // Spawn 6G AI-native network function tasks (Rel-20). The 6G crates are
+        // optional (off by default); the whole block compiles away when none of
+        // the `nextgsim-*` features are enabled. A `*_enabled` config flag set
+        // without its feature compiled in is a no-op — mirroring the UE side.
+        #[cfg(any(
+            feature = "nextgsim-she",
+            feature = "nextgsim-nwdaf",
+            feature = "nextgsim-nkef",
+            feature = "nextgsim-isac",
+            feature = "nextgsim-agent",
+            feature = "nextgsim-fl",
+        ))]
+        {
+            let any_6g = cfg!(feature = "nextgsim-she") && task_base.config.she_enabled
+                || cfg!(feature = "nextgsim-nwdaf") && task_base.config.nwdaf_enabled
+                || cfg!(feature = "nextgsim-nkef") && task_base.config.nkef_enabled
+                || cfg!(feature = "nextgsim-isac") && task_base.config.isac_enabled
+                || cfg!(feature = "nextgsim-agent") && task_base.config.agent_enabled
+                || cfg!(feature = "nextgsim-fl") && task_base.config.federated_learning_enabled;
 
-        if any_6g {
-            let sixg_rxs = task_base.init_6g_tasks(DEFAULT_CHANNEL_CAPACITY);
+            if any_6g {
+                let sixg_rxs = task_base.init_6g_tasks(DEFAULT_CHANNEL_CAPACITY);
 
-            if task_base.config.she_enabled {
-                let mut she_task = SheTask::new(task_base.clone());
-                tokio::spawn(async move {
-                    she_task.run(sixg_rxs.she_rx).await;
-                    Ok::<(), TaskError>(())
-                });
-                info!("SHE task spawned");
-            }
+                #[cfg(feature = "nextgsim-she")]
+                if task_base.config.she_enabled {
+                    let mut she_task = SheTask::new(task_base.clone());
+                    tokio::spawn(async move {
+                        she_task.run(sixg_rxs.she_rx).await;
+                        Ok::<(), TaskError>(())
+                    });
+                    info!("SHE task spawned");
+                }
 
-            if task_base.config.nwdaf_enabled {
-                let mut nwdaf_task = NwdafTask::new(task_base.clone());
-                tokio::spawn(async move {
-                    nwdaf_task.run(sixg_rxs.nwdaf_rx).await;
-                    Ok::<(), TaskError>(())
-                });
-                info!("NWDAF task spawned");
-            }
+                #[cfg(feature = "nextgsim-nwdaf")]
+                if task_base.config.nwdaf_enabled {
+                    let mut nwdaf_task = NwdafTask::new(task_base.clone());
+                    tokio::spawn(async move {
+                        nwdaf_task.run(sixg_rxs.nwdaf_rx).await;
+                        Ok::<(), TaskError>(())
+                    });
+                    info!("NWDAF task spawned");
+                }
 
-            if task_base.config.nkef_enabled {
-                let mut nkef_task = NkefTask::new(task_base.clone());
-                tokio::spawn(async move {
-                    nkef_task.run(sixg_rxs.nkef_rx).await;
-                    Ok::<(), TaskError>(())
-                });
-                info!("NKEF task spawned");
-            }
+                #[cfg(feature = "nextgsim-nkef")]
+                if task_base.config.nkef_enabled {
+                    let mut nkef_task = NkefTask::new(task_base.clone());
+                    tokio::spawn(async move {
+                        nkef_task.run(sixg_rxs.nkef_rx).await;
+                        Ok::<(), TaskError>(())
+                    });
+                    info!("NKEF task spawned");
+                }
 
-            if task_base.config.isac_enabled {
-                let mut isac_task = IsacTask::new(task_base.clone());
-                tokio::spawn(async move {
-                    isac_task.run(sixg_rxs.isac_rx).await;
-                    Ok::<(), TaskError>(())
-                });
-                info!("ISAC task spawned");
-            }
+                #[cfg(feature = "nextgsim-isac")]
+                if task_base.config.isac_enabled {
+                    let mut isac_task = IsacTask::new(task_base.clone());
+                    tokio::spawn(async move {
+                        isac_task.run(sixg_rxs.isac_rx).await;
+                        Ok::<(), TaskError>(())
+                    });
+                    info!("ISAC task spawned");
+                }
 
-            if task_base.config.agent_enabled {
-                let mut agent_task = AgentTask::new(task_base.clone());
-                tokio::spawn(async move {
-                    agent_task.run(sixg_rxs.agent_rx).await;
-                    Ok::<(), TaskError>(())
-                });
-                info!("Agent task spawned");
-            }
+                #[cfg(feature = "nextgsim-agent")]
+                if task_base.config.agent_enabled {
+                    let mut agent_task = AgentTask::new(task_base.clone());
+                    tokio::spawn(async move {
+                        agent_task.run(sixg_rxs.agent_rx).await;
+                        Ok::<(), TaskError>(())
+                    });
+                    info!("Agent task spawned");
+                }
 
-            if task_base.config.federated_learning_enabled {
-                let mut fl_task = FlAggregatorTask::new(task_base.clone());
-                tokio::spawn(async move {
-                    fl_task.run(sixg_rxs.fl_rx).await;
-                    Ok::<(), TaskError>(())
-                });
-                info!("FL Aggregator task spawned");
+                #[cfg(feature = "nextgsim-fl")]
+                if task_base.config.federated_learning_enabled {
+                    let mut fl_task = FlAggregatorTask::new(task_base.clone());
+                    tokio::spawn(async move {
+                        fl_task.run(sixg_rxs.fl_rx).await;
+                        Ok::<(), TaskError>(())
+                    });
+                    info!("FL Aggregator task spawned");
+                }
             }
         }
     }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[features]
+# Enables the 6G AI-native integration tests (src/sixg_task_integration.rs),
+# which drive the optional 6G task types re-exported only from a `--features 6g`
+# build of nextgsim-gnb. Off by default so `cargo test --workspace` exercises the
+# lean gNB build. Run the 6G tests with:
+#   cargo test -p nextgsim-integration-tests --features 6g
+6g = ["nextgsim-gnb/6g"]
+
 [dependencies]
 # Internal crates
 nextgsim-common = { path = "../nextgsim-common" }

--- a/tests/src/sixg_task_integration.rs
+++ b/tests/src/sixg_task_integration.rs
@@ -7,7 +7,13 @@
 //! - Message delivery through mpsc channels to running task loops
 //! - State transitions inside each task (Agent, FL, ISAC, NWDAF)
 //! - NWDAF → RRC handover recommendation cross-task wiring
+//!
+//! The 6G task types (`AgentTask`/`FlAggregatorTask`/`IsacTask`/`NwdafTask`) are
+//! only re-exported from a `--features 6g` build of `nextgsim-gnb`, so this whole
+//! test binary is gated on the tests crate's `6g` feature (see Cargo.toml). Under
+//! a default (lean) `cargo test --workspace` it compiles to an empty binary.
 
+#![cfg(feature = "6g")]
 #![allow(unused_imports)]
 
 use std::time::Duration;


### PR DESCRIPTION
## Summary

Brings `nextgsim-gnb` to parity with `nextgsim-ue`: the six 6G / AI-native research crates (`she`, `nwdaf`, `nkef`, `isac`, `agent`, `fl`) become **optional** Cargo dependencies, off by default. `cargo build -p nextgsim-gnb` now yields a lean 5G gNB with none of them compiled in. There is no frozen 3GPP Rel-20/6G Stage-3 spec behind these crates, so keeping them out of a lean baseline build is desirable.

## Changes

- **`Cargo.toml`**: the six crates are `optional = true`; new `6g` umbrella feature enables all of them at once.
- **`lib.rs`**: the six `pub mod` declarations and their `pub use` re-exports are gated behind the matching `nextgsim-*` feature.
- **`main.rs`**: the six task-type imports and each per-NF spawn arm are `cfg`-gated, and the whole 6G spawn block sits behind `cfg(any(feature = ...))`. `any_6g` now combines `cfg!(feature) && config.*_enabled`, so a config flag set without the feature compiled in is a no-op (matching the UE).
- **`tests/`**: the 6G integration tests (`sixg_task_integration`) drive the optional task types, so they are gated behind a new `6g` feature on the tests crate (forwarding to `nextgsim-gnb/6g`). This keeps `cargo test --workspace` exercising the **lean** gNB build (so CI verifies the lean build stays green); run the 6G tests with `cargo test -p nextgsim-integration-tests --features 6g`.

The `*_enabled` config bools stay unconditional, so YAML parsing is unaffected and existing configs behave identically (all default `false`).

## Verification (all acceptance criteria)

- `cargo build -p nextgsim-gnb` compiles; `cargo tree -p nextgsim-gnb` shows the six 6G crates **absent**.
- `cargo build -p nextgsim-gnb --features 6g` compiles; the 6G crates are **present** in the tree.
- `cargo clippy` clean for **both** the default and `--features 6g` builds.
- `cargo check --workspace --all-targets` (lean) compiles every target.
- `cargo test --workspace` passes on the lean build; the 6G integration tests pass under `--features 6g`.
- A lean build with a config that sets e.g. `she_enabled: true` is a compile-time no-op (the whole 6G block is `cfg`-gated out) — no panic.

## Note on scope

The UE-side `6g` umbrella feature (issue's optional polish) is intentionally left out to keep this change focused on the gNB — the actual asymmetry. It can be added separately.

Closes #24
