### PR TITLE
feat(gnb): apply served-GUAMI + PLMN-support lists on AMF Configuration Update (Related #41)

### DIFF
--- a/nextgsim-gnb/src/ngap/task.rs
+++ b/nextgsim-gnb/src/ngap/task.rs
@@ -2399,9 +2399,9 @@ impl NgapTask {
              plmn_support={}",
             client_id,
             update.amf_name,
-            update.served_guami_count,
+            update.served_guami_list.len(),
             update.relative_amf_capacity,
-            update.has_plmn_support_list
+            update.plmn_support_list.len()
         );
 
         if let Some(ctx) = self.amf_contexts.get_mut(&client_id) {
@@ -2410,6 +2410,14 @@ impl NgapTask {
             }
             if let Some(cap) = update.relative_amf_capacity {
                 ctx.relative_capacity = cap;
+            }
+            // TS 38.413 §8.7.3: apply the updated served-GUAMI and PLMN-support
+            // lists when present (an empty list means the IE was absent).
+            if !update.served_guami_list.is_empty() {
+                ctx.served_guami_list = update.served_guami_list.clone();
+            }
+            if !update.plmn_support_list.is_empty() {
+                ctx.plmn_support_list = update.plmn_support_list.clone();
             }
         }
 
@@ -4524,6 +4532,58 @@ mod tests {
         assert!(
             sctp_rx.try_recv().is_err(),
             "AMF Status Indication must not be answered with an Error Indication"
+        );
+    }
+
+    /// AMF CONFIGURATION UPDATE applies the served-GUAMI and PLMN-support lists
+    /// (not just their counts) to the stored AMF context and is acknowledged
+    /// (TS 38.413 §8.7.3).
+    #[tokio::test]
+    async fn test_amf_configuration_update_applies_guami_and_plmn_lists() {
+        use nextgsim_ngap::procedures::ng_reset::AmfConfigurationUpdateData;
+        use nextgsim_ngap::procedures::{Guami, PlmnSupportItem, SNssai, ServedGuamiItem};
+
+        let config = test_config();
+        let (task_base, _app_rx, _ngap_rx, _rrc_rx, _gtp_rx, _rls_rx, mut sctp_rx) =
+            GnbTaskBase::new(config, DEFAULT_CHANNEL_CAPACITY);
+        let mut task = NgapTask::new(task_base);
+        task.create_amf_context(1);
+        if let Some(ctx) = task.find_amf_context_mut(1) {
+            ctx.on_association_up(100, 4, 4);
+            ctx.state = AmfState::Ready;
+        }
+
+        let update = AmfConfigurationUpdateData {
+            amf_name: Some("amf-new".into()),
+            served_guami_list: vec![ServedGuamiItem {
+                guami: Guami {
+                    plmn_identity: [0x00, 0xf1, 0x10],
+                    amf_region_id: 1,
+                    amf_set_id: 2,
+                    amf_pointer: 3,
+                },
+                backup_amf_name: None,
+            }],
+            relative_amf_capacity: Some(200),
+            plmn_support_list: vec![PlmnSupportItem {
+                plmn_identity: [0x00, 0xf1, 0x10],
+                slice_support_list: vec![SNssai { sst: 1, sd: None }],
+            }],
+        };
+        task.handle_amf_configuration_update(1, 0, update).await;
+
+        let ctx = task.find_amf_context_mut(1).unwrap();
+        assert_eq!(ctx.amf_name.as_deref(), Some("amf-new"));
+        assert_eq!(ctx.relative_capacity, 200);
+        assert_eq!(ctx.served_guami_list.len(), 1);
+        assert_eq!(ctx.served_guami_list[0].guami.amf_set_id, 2);
+        assert_eq!(ctx.plmn_support_list.len(), 1);
+        assert_eq!(ctx.plmn_support_list[0].slice_support_list[0].sst, 1);
+
+        // An AMF Configuration Update Acknowledge was sent.
+        assert!(
+            sctp_rx.try_recv().is_ok(),
+            "must reply with an AMF Configuration Update Acknowledge"
         );
     }
 }

--- a/nextgsim-ngap/src/procedures/ng_reset.rs
+++ b/nextgsim-ngap/src/procedures/ng_reset.rs
@@ -18,7 +18,10 @@
 
 use crate::codec::generated::*;
 use crate::codec::{decode_ngap_pdu, encode_ngap_pdu, NgapCodecError};
-use crate::procedures::ng_setup::{parse_cause, NgSetupFailureCause};
+use crate::procedures::ng_setup::{
+    parse_cause, parse_plmn_support_list, parse_served_guami_list, NgSetupFailureCause,
+    PlmnSupportItem, ServedGuamiItem,
+};
 use thiserror::Error;
 
 /// Errors that can occur during NG Reset / AMF Configuration Update handling.
@@ -252,12 +255,12 @@ pub fn decode_ng_reset_acknowledge(bytes: &[u8]) -> Result<NgResetAcknowledgePar
 pub struct AmfConfigurationUpdateData {
     /// Updated AMF name, if present.
     pub amf_name: Option<String>,
-    /// Number of served GUAMIs advertised (0 if the IE is absent).
-    pub served_guami_count: usize,
+    /// Updated served-GUAMI list (empty if the IE is absent).
+    pub served_guami_list: Vec<ServedGuamiItem>,
     /// Relative AMF capacity (0..255), if present.
     pub relative_amf_capacity: Option<u8>,
-    /// Whether a PLMN Support List IE was included.
-    pub has_plmn_support_list: bool,
+    /// Updated PLMN support list (empty if the IE is absent).
+    pub plmn_support_list: Vec<PlmnSupportItem>,
 }
 
 /// Parameters for building an AMF Configuration Update Acknowledge.
@@ -310,13 +313,13 @@ pub fn parse_amf_configuration_update(
                 data.amf_name = Some(name.0.clone());
             }
             AMFConfigurationUpdateProtocolIEs_EntryValue::Id_ServedGUAMIList(list) => {
-                data.served_guami_count = list.0.len();
+                data.served_guami_list = parse_served_guami_list(list);
             }
             AMFConfigurationUpdateProtocolIEs_EntryValue::Id_RelativeAMFCapacity(cap) => {
                 data.relative_amf_capacity = Some(cap.0);
             }
-            AMFConfigurationUpdateProtocolIEs_EntryValue::Id_PLMNSupportList(_) => {
-                data.has_plmn_support_list = true;
+            AMFConfigurationUpdateProtocolIEs_EntryValue::Id_PLMNSupportList(list) => {
+                data.plmn_support_list = parse_plmn_support_list(list);
             }
             _ => {}
         }

--- a/nextgsim-ngap/src/procedures/ng_setup.rs
+++ b/nextgsim-ngap/src/procedures/ng_setup.rs
@@ -475,7 +475,7 @@ pub fn parse_ng_setup_response(pdu: &NGAP_PDU) -> Result<NgSetupResponseData, Ng
     })
 }
 
-fn parse_served_guami_list(list: &ServedGUAMIList) -> Vec<ServedGuamiItem> {
+pub(crate) fn parse_served_guami_list(list: &ServedGUAMIList) -> Vec<ServedGuamiItem> {
     list.0
         .iter()
         .map(|item| {
@@ -545,7 +545,7 @@ fn parse_guami(guami: &GUAMI) -> Guami {
     }
 }
 
-fn parse_plmn_support_list(list: &PLMNSupportList) -> Vec<PlmnSupportItem> {
+pub(crate) fn parse_plmn_support_list(list: &PLMNSupportList) -> Vec<PlmnSupportItem> {
     list.0
         .iter()
         .map(|item| {


### PR DESCRIPTION
## Summary

Next Phase-1 piece of #41. AMF CONFIGURATION UPDATE (TS 38.413 §8.7.3) only stored the AMF name and relative capacity; the parser **counted and discarded** the served-GUAMI and PLMN-support lists, so the gNB's view of an AMF's GUAMIs/slices went stale on any reconfiguration.

## Changes

- `AmfConfigurationUpdateData` now carries `served_guami_list: Vec<ServedGuamiItem>` and `plmn_support_list: Vec<PlmnSupportItem>` (was `served_guami_count` / `has_plmn_support_list`). The parser populates them by **reusing** ng_setup's `parse_served_guami_list` / `parse_plmn_support_list` (now `pub(crate)`) — the same helpers the NG Setup Response uses.
- `handle_amf_configuration_update` applies the two lists to the stored AMF context when present. The AMF Configuration Update Acknowledge is unchanged.

## Testing

- gNB integration: an AMF Configuration Update carrying a GUAMI + PLMN-support entry updates the stored context's `served_guami_list` / `plmn_support_list` (and name/capacity) and is acknowledged.
- Gate: `cargo fmt --check`, `cargo clippy --workspace` (clean), `cargo test --workspace` (3281 passed / 0 failed).

## Deferred (#41 remainder)

TNLA add/update/remove processing on AMF Configuration Update; RAN Configuration Update initiate; slice-aware `select_amf`; and the GUAMI / AMF-set / TNLA identity model.

Related #41
