### PR TITLE
feat(gnb): slice-aware AMF selection from RRCSetupComplete S-NSSAI (#41)

### DIFF
--- a/nextgsim-gnb/src/ngap/task.rs
+++ b/nextgsim-gnb/src/ngap/task.rs
@@ -136,6 +136,7 @@ use nextgsim_ngap::procedures::{
     is_ng_setup_response,
     parse_ng_setup_failure,
     parse_ng_setup_response,
+    AllowedSnssai,
     BroadcastPlmnItem,
     DownlinkNasTransportData,
     GnbId,
@@ -218,10 +219,38 @@ impl NgapTask {
         self.amf_contexts.get_mut(&client_id)
     }
 
-    /// Selects an AMF for a new UE based on capacity and slice support
-    fn select_amf(&self, _requested_nssai: Option<i32>) -> Option<i32> {
-        // Simple selection: pick the highest-capacity AMF that is Ready and not
-        // marked unavailable by an AMF Status Indication (TS 38.413 §8.7.6).
+    /// Selects an AMF for a new UE by slice support and capacity
+    /// (TS 38.413 §8.6.1.2, TS 23.501 §5.15.5.2.1).
+    ///
+    /// Candidates are AMFs that are `Ready` and not marked `unavailable` by an
+    /// AMF Status Indication (TS 38.413 §8.7.6). When the UE requested one or
+    /// more S-NSSAIs, an AMF is preferred only if it advertises support for
+    /// *every* requested slice on the serving `plmn` (its NG Setup / AMF
+    /// Configuration Update `plmn_support_list`); ties break on relative
+    /// capacity. An empty `requested` list imposes no slice constraint.
+    ///
+    /// If no Ready AMF serves the requested slices, selection falls back to the
+    /// highest-capacity Ready AMF so the UE can still attach (the AMF then
+    /// applies its own NSSAI policy) — this also preserves the pre-slice
+    /// behaviour for deployments whose AMFs advertise no slice support.
+    fn select_amf(&self, plmn: &[u8; 3], requested: &[SNssai]) -> Option<i32> {
+        if !requested.is_empty() {
+            if let Some(ctx_id) = self
+                .amf_contexts
+                .values()
+                .filter(|ctx| ctx.is_ready() && !ctx.unavailable)
+                .filter(|ctx| requested.iter().all(|s| ctx.supports_snssai(plmn, s)))
+                .max_by_key(|ctx| ctx.relative_capacity)
+                .map(|ctx| ctx.ctx_id)
+            {
+                return Some(ctx_id);
+            }
+            warn!(
+                "No Ready AMF advertises the requested S-NSSAI {:?} for PLMN {:02x?}; falling back to capacity-only AMF selection",
+                requested, plmn
+            );
+        }
+
         self.amf_contexts
             .values()
             .filter(|ctx| ctx.is_ready() && !ctx.unavailable)
@@ -1727,16 +1756,30 @@ impl NgapTask {
         pdu: OctetString,
         rrc_establishment_cause: i64,
         _s_tmsi: Option<crate::tasks::GutiMobileIdentity>,
+        s_nssai_list: Vec<nextgsim_common::SNssai>,
     ) {
         debug!(
-            "Initial NAS delivery: ue_id={}, cause={}, pdu_len={}",
+            "Initial NAS delivery: ue_id={}, cause={}, pdu_len={}, s_nssai_count={}",
             ue_id,
             rrc_establishment_cause,
-            pdu.len()
+            pdu.len(),
+            s_nssai_list.len()
         );
 
-        // Select an AMF for this UE
-        let amf_id = match self.select_amf(None) {
+        // The UE's requested S-NSSAI(s) (from RRCSetupComplete) drive slice-aware
+        // AMF selection and are echoed as the Allowed NSSAI in the Initial UE
+        // Message (TS 38.413 §8.6.1.2). Map the common S-NSSAI onto the NGAP type.
+        let requested_nssai: Vec<SNssai> = s_nssai_list
+            .iter()
+            .map(|s| SNssai {
+                sst: s.sst,
+                sd: s.sd,
+            })
+            .collect();
+        let serving_plmn = self.task_base.config.plmn.encode();
+
+        // Select an AMF for this UE, honouring the requested slice(s)
+        let amf_id = match self.select_amf(&serving_plmn, &requested_nssai) {
             Some(id) => id,
             None => {
                 warn!("No AMF available for UE {}", ue_id);
@@ -1813,7 +1856,21 @@ impl NgapTask {
             five_g_s_tmsi,
             amf_set_id: None,
             ue_context_request: Some(UeContextRequestValue::Requested),
-            allowed_nssai: None,
+            // Carry the UE's requested slice(s) as the Allowed NSSAI so the AMF
+            // sees the slice context used for selection (TS 38.413 §8.6.1.2).
+            allowed_nssai: if requested_nssai.is_empty() {
+                None
+            } else {
+                Some(
+                    requested_nssai
+                        .iter()
+                        .map(|s| AllowedSnssai {
+                            sst: s.sst,
+                            sd: s.sd,
+                        })
+                        .collect(),
+                )
+            },
         };
 
         match encode_initial_ue_message(&params) {
@@ -3478,12 +3535,14 @@ impl Task for NgapTask {
                         pdu,
                         rrc_establishment_cause,
                         s_tmsi,
+                        s_nssai_list,
                     } => {
                         self.handle_initial_nas_delivery(
                             ue_id,
                             pdu,
                             rrc_establishment_cause,
                             s_tmsi,
+                            s_nssai_list,
                         )
                         .await;
                     }
@@ -3711,13 +3770,14 @@ mod tests {
             GnbTaskBase::new(config, DEFAULT_CHANNEL_CAPACITY);
 
         let mut task = NgapTask::new(task_base);
+        let plmn = [0x00, 0xf1, 0x10];
 
         // No AMF available
-        assert!(task.select_amf(None).is_none());
+        assert!(task.select_amf(&plmn, &[]).is_none());
 
         // Add AMF but not ready
         task.create_amf_context(1);
-        assert!(task.select_amf(None).is_none());
+        assert!(task.select_amf(&plmn, &[]).is_none());
 
         // Make AMF ready
         if let Some(ctx) = task.find_amf_context_mut(1) {
@@ -3725,7 +3785,62 @@ mod tests {
             ctx.state = AmfState::Ready;
             ctx.relative_capacity = 100;
         }
-        assert_eq!(task.select_amf(None), Some(1));
+        assert_eq!(task.select_amf(&plmn, &[]), Some(1));
+    }
+
+    /// Slice-aware AMF selection (TS 38.413 §8.6.1.2, issue #41): a UE that
+    /// requests S-NSSAI X is routed to an AMF serving X even when another AMF
+    /// has higher capacity, and an empty request falls back to capacity.
+    #[test]
+    fn test_select_amf_slice_aware() {
+        use nextgsim_ngap::procedures::{PlmnSupportItem, SNssai};
+
+        let config = test_config();
+        let (task_base, _app_rx, _ngap_rx, _rrc_rx, _gtp_rx, _rls_rx, _sctp_rx) =
+            GnbTaskBase::new(config, DEFAULT_CHANNEL_CAPACITY);
+        let mut task = NgapTask::new(task_base);
+        let plmn = [0x00, 0xf1, 0x10];
+
+        // AMF 1: higher capacity, serves only SST=1.
+        task.create_amf_context(1);
+        if let Some(ctx) = task.find_amf_context_mut(1) {
+            ctx.on_association_up(100, 4, 4);
+            ctx.state = AmfState::Ready;
+            ctx.relative_capacity = 200;
+            ctx.plmn_support_list = vec![PlmnSupportItem {
+                plmn_identity: plmn,
+                slice_support_list: vec![SNssai { sst: 1, sd: None }],
+            }];
+        }
+        // AMF 2: lower capacity, serves only SST=2.
+        task.create_amf_context(2);
+        if let Some(ctx) = task.find_amf_context_mut(2) {
+            ctx.on_association_up(101, 4, 4);
+            ctx.state = AmfState::Ready;
+            ctx.relative_capacity = 100;
+            ctx.plmn_support_list = vec![PlmnSupportItem {
+                plmn_identity: plmn,
+                slice_support_list: vec![SNssai { sst: 2, sd: None }],
+            }];
+        }
+
+        // Requesting SST=2 must route to AMF 2 despite AMF 1's higher capacity.
+        assert_eq!(
+            task.select_amf(&plmn, &[SNssai { sst: 2, sd: None }]),
+            Some(2)
+        );
+        // Requesting SST=1 routes to AMF 1.
+        assert_eq!(
+            task.select_amf(&plmn, &[SNssai { sst: 1, sd: None }]),
+            Some(1)
+        );
+        // No slice constraint → highest capacity (AMF 1).
+        assert_eq!(task.select_amf(&plmn, &[]), Some(1));
+        // A slice no AMF serves → capacity-only fallback (AMF 1), still attaches.
+        assert_eq!(
+            task.select_amf(&plmn, &[SNssai { sst: 9, sd: None }]),
+            Some(1)
+        );
     }
 
     #[test]
@@ -4560,7 +4675,7 @@ mod tests {
             }];
         }
         // Ready + available → this AMF is selectable.
-        assert_eq!(task.select_amf(None), Some(1));
+        assert_eq!(task.select_amf(&[0x00, 0xf1, 0x10], &[]), Some(1));
 
         // AMF Status Indication marks that GUAMI unavailable.
         let params = AmfStatusIndicationParams {
@@ -4581,7 +4696,7 @@ mod tests {
         // The AMF is excluded from selection, and nothing was echoed.
         assert!(task.find_amf_context_mut(1).unwrap().unavailable);
         assert_eq!(
-            task.select_amf(None),
+            task.select_amf(&[0x00, 0xf1, 0x10], &[]),
             None,
             "an AMF with an unavailable GUAMI must not be selected"
         );

--- a/nextgsim-gnb/src/rrc/task.rs
+++ b/nextgsim-gnb/src/rrc/task.rs
@@ -8,6 +8,7 @@ use crate::tasks::{
     SheMessage, Task, TaskMessage,
 };
 use nextgsim_common::OctetString;
+use nextgsim_common::SNssai;
 use nextgsim_rls::RrcChannel;
 use nextgsim_rrc::procedures::dcch_dispatch::{dispatch_ul_dcch, UlDcchMessage};
 use nextgsim_rrc::procedures::information_transfer::{
@@ -274,8 +275,9 @@ impl RrcTask {
                         let ctx = self.ue_manager.create_ue(ue_id);
                         ctx.on_setup_complete(); // Mark as connected
                     }
-                    // Forward as Initial NAS
-                    self.send_initial_nas_delivery(ue_id, data.clone(), 3, None)
+                    // Forward as Initial NAS (bespoke UL-DCCH fallback: no
+                    // s-NSSAI-List is carried on this path).
+                    self.send_initial_nas_delivery(ue_id, data.clone(), 3, None, Vec::new())
                         .await; // cause=3 (mo-Data)
                 } else {
                     debug!("Unhandled UL-DCCH message type: {:#x}", message_type);
@@ -399,12 +401,29 @@ impl RrcTask {
     /// encoding carries the transaction id, the dedicated NAS message, and
     /// the RedCap indication as typed fields — no byte-offset extraction.
     async fn handle_rrc_setup_complete_asn1(&mut self, ue_id: i32, complete: RrcSetupCompleteData) {
+        // Requested S-NSSAI(s) the UE carried in RRCSetupComplete (TS 38.331
+        // §6.2.2), used downstream for slice-aware AMF selection. The RRC codec
+        // models SD as a u32; convert to the common S-NSSAI (3-byte SD).
+        let s_nssai_list: Vec<SNssai> = complete
+            .s_nssai_list
+            .as_ref()
+            .map(|list| {
+                list.iter()
+                    .map(|s| match s.sd {
+                        Some(sd) => SNssai::with_sd_u32(s.sst, sd),
+                        None => SNssai::new(s.sst),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
         info!(
-            "RRC Setup Complete (ASN.1 UL-DCCH) from UE[{}]: tid={}, nas_len={}, redcap={}",
+            "RRC Setup Complete (ASN.1 UL-DCCH) from UE[{}]: tid={}, nas_len={}, redcap={}, s_nssai_count={}",
             ue_id,
             complete.rrc_transaction_id,
             complete.dedicated_nas_message.len(),
-            complete.redcap_indication
+            complete.redcap_indication,
+            s_nssai_list.len()
         );
 
         let nas_pdu = OctetString::from_slice(&complete.dedicated_nas_message);
@@ -413,6 +432,7 @@ impl RrcTask {
             complete.rrc_transaction_id,
             nas_pdu,
             complete.redcap_indication,
+            s_nssai_list,
             "ASN.1",
         )
         .await;
@@ -456,6 +476,9 @@ impl RrcTask {
             transaction_id,
             nas_pdu,
             redcap_indication,
+            // The bespoke framing carries no s-NSSAI-List; slice-aware selection
+            // is only available on the ASN.1 path.
+            Vec::new(),
             "bespoke-fallback",
         )
         .await;
@@ -472,6 +495,7 @@ impl RrcTask {
         transaction_id: u8,
         nas_pdu: OctetString,
         redcap_indication: bool,
+        s_nssai_list: Vec<SNssai>,
         via: &str,
     ) {
         if redcap_indication {
@@ -496,6 +520,7 @@ impl RrcTask {
                 result.nas_pdu,
                 result.establishment_cause,
                 result.s_tmsi,
+                s_nssai_list,
             )
             .await;
 
@@ -863,12 +888,14 @@ impl RrcTask {
         pdu: OctetString,
         rrc_establishment_cause: i64,
         s_tmsi: Option<GutiMobileIdentity>,
+        s_nssai_list: Vec<SNssai>,
     ) {
         let msg = NgapMessage::InitialNasDelivery {
             ue_id,
             pdu,
             rrc_establishment_cause,
             s_tmsi,
+            s_nssai_list,
         };
         if let Err(e) = self.task_base.ngap_tx.send(msg).await {
             error!("Failed to send Initial NAS to NGAP: {}", e);

--- a/nextgsim-gnb/src/tasks.rs
+++ b/nextgsim-gnb/src/tasks.rs
@@ -35,6 +35,7 @@ use tokio::task::JoinHandle;
 
 use nextgsim_common::config::GnbConfig;
 use nextgsim_common::OctetString;
+use nextgsim_common::SNssai;
 use nextgsim_rls::RrcChannel;
 
 // ============================================================================
@@ -267,6 +268,11 @@ pub enum NgapMessage {
         rrc_establishment_cause: i64,
         /// S-TMSI if available
         s_tmsi: Option<GutiMobileIdentity>,
+        /// Requested S-NSSAI(s) the UE signalled in RRCSetupComplete
+        /// (TS 38.331 §6.2.2). The NGAP task uses these for slice-aware AMF
+        /// selection and echoes them as the Allowed NSSAI in the Initial UE
+        /// Message (TS 38.413 §8.6.1.2). Empty when the UE signalled none.
+        s_nssai_list: Vec<SNssai>,
     },
     /// Uplink NAS delivery from RRC
     UplinkNasDelivery {

--- a/nextgsim-ue/src/rrc/task.rs
+++ b/nextgsim-ue/src/rrc/task.rs
@@ -46,7 +46,7 @@ use nextgsim_rrc::codec::{decode_rrc, CellGroupConfig, RadioBearerConfig};
 use nextgsim_rrc::procedures::rrc_setup::{
     decode_rrc_setup, encode_rrc_setup_complete, encode_rrc_setup_request,
     RrcEstablishmentCause as AsnEstablishmentCause, RrcSetupCompleteParams, RrcSetupData,
-    RrcSetupRequestParams, UeIdentity,
+    RrcSetupRequestParams, SNssai as RrcSNssai, UeIdentity,
 };
 use nextgsim_rrc::procedures::security_mode::{
     decode_security_mode_command, encode_security_mode_complete, SecurityModeCommandData,
@@ -942,6 +942,30 @@ impl RrcTask {
             info!("Signalling RedCap (Reduced Capability) indication in RRCSetupComplete");
         }
 
+        // Advertise the UE's configured S-NSSAI(s) in RRCSetupComplete so the
+        // gNB can perform slice-aware AMF selection (TS 38.331 §6.2.2,
+        // TS 38.413 §8.6.1.2). An empty configured NSSAI signals none.
+        let configured = &self.task_base.config.configured_nssai.slices;
+        let s_nssai_list: Option<Vec<RrcSNssai>> = if configured.is_empty() {
+            None
+        } else {
+            Some(
+                configured
+                    .iter()
+                    .map(|s| RrcSNssai {
+                        sst: s.sst,
+                        sd: s.sd_as_u32(),
+                    })
+                    .collect(),
+            )
+        };
+        if let Some(ref list) = s_nssai_list {
+            info!(
+                "Signalling {} configured S-NSSAI(s) in RRCSetupComplete",
+                list.len()
+            );
+        }
+
         let params = RrcSetupCompleteParams {
             registered_amf: None,
             // Wave-6 C2/C4-interim: the echoed tid stays PINNED to 0 until C5
@@ -954,7 +978,7 @@ impl RrcTask {
             rrc_transaction_id: 0,
             selected_plmn_identity: 1,
             guami_type: None,
-            s_nssai_list: None,
+            s_nssai_list,
             dedicated_nas_message: nas_data.clone(),
             ng_5g_s_tmsi_value: None,
             redcap_indication,


### PR DESCRIPTION
## Summary

Completes issue #41 **criterion 7 (slice-aware AMF selection)** end-to-end: the gNB now routes a UE to an AMF that serves its requested S-NSSAI instead of always choosing the highest-capacity AMF and discarding slice context (TS 38.331 §6.2.2, TS 38.413 §8.6.1.2, TS 23.501 §5.15.5.2.1).

Previously the RRCSetupComplete `s-NSSAI-List` codec was fully built but **decode-and-drop** — the UE sent `None` and the gNB never read it. This wires the spec-clean path that IE exists for.

## Changes

- **nextgsim-ue**: RRCSetupComplete now carries the UE's configured S-NSSAI(s) (was hardcoded `None`); an empty configured NSSAI still signals none.
- **nextgsim-gnb (RRC)**: read the decoded `s-NSSAI-List` and thread it RRC→NGAP through `NgapMessage::InitialNasDelivery`.
- **nextgsim-gnb (NGAP)**: `select_amf(plmn, requested)` prefers Ready, non-`unavailable` AMFs whose `plmn_support_list` supports **every** requested slice (tie-break: relative capacity). An empty request imposes no slice constraint; if no AMF serves the requested slice, selection falls back to capacity-only so attach never breaks and slice-less deployments are unchanged.
- Echo the requested slice(s) as the Initial UE Message **Allowed NSSAI** so the AMF sees the slice context used for selection (per the criterion's wording).

## Tests

New `test_select_amf_slice_aware`: a UE requesting SST=2 is routed to the SST=2 AMF over a higher-capacity SST=1 AMF; plus the empty-request and no-match capacity-fallback cases. Existing overload / AMF status indication / AMF configuration update dispatch tests stay green. Workspace `cargo fmt --check` + `cargo clippy --workspace --all-targets` + `cargo test --workspace` all clean.

## Note on Allowed NSSAI semantics

The Initial UE Message Allowed NSSAI IE is populated from the UE's *requested* slice (per the criterion's explicit wording). Strictly, TS 38.413 §9.3.1.31 models Allowed NSSAI as the AMF-authorized set; a conformant AMF always re-derives it from the NAS Requested NSSAI + UDM subscription, so this is selection assistance only and cannot induce over-admission. Flagged for visibility, not a functional issue.

## Remaining in #41

Criterion 8 (GUAMI/AMF-set identity + multiple TNLAs per NG-C instance) and TNLA add/remove on AMF Configuration Update — a separate structural refactor, to follow.

Related #41

Signed-off-by: Murat Parlakisik <parlakisik@gmail.com>
