### PR TITLE
feat(ue): drive PLMN selection from the live RRC available-PLMN report (#49)

### DIFF
--- a/nextgsim-ue/src/main.rs
+++ b/nextgsim-ue/src/main.rs
@@ -719,8 +719,17 @@ impl UeApp {
                                 .await;
                             }
                         }
-                        NasMessage::ActiveCellChanged { previous_tai } => {
+                        NasMessage::ActiveCellChanged {
+                            previous_tai,
+                            available_plmns: reported_plmns,
+                        } => {
                             info!("Active cell changed from TAI: {:?}", previous_tai);
+                            // Refresh the selector's available-PLMN candidate set
+                            // from the radio report (TS 23.122 §4.4.3); an empty
+                            // report leaves the last-known set in place.
+                            if !reported_plmns.is_empty() {
+                                plmn_selector.set_available_plmns(reported_plmns);
+                            }
                             if orch.state().is_registered() {
                                 // Mobility registration update trigger
                                 // (TS 24.501 Section 5.5.1.3.2)
@@ -1494,10 +1503,18 @@ async fn perform_plmn_selection(
     plmn_selector.set_forbidden(forbidden);
     plmn_selector.set_registered_plmn(None);
 
-    // Available PLMNs: in this simulation every cell in the gNB search
-    // list broadcasts the configured home PLMN
-    let available = [home_plmn];
-    match plmn_selector.select(&available) {
+    // Candidate PLMNs come from the live RRC available-PLMN report cached in
+    // the selector (CellSelector::available_plmns, TS 23.122 §4.4.3); fall back
+    // to the home PLMN when the radio has reported none yet.
+    let candidates: Vec<_> = {
+        let reported = plmn_selector.available_plmns();
+        if reported.is_empty() {
+            vec![home_plmn]
+        } else {
+            reported.to_vec()
+        }
+    };
+    match plmn_selector.select(&candidates) {
         Some(plmn) => {
             info!("PLMN selection chose {plmn}: attempting registration");
             let outs = orch.start_registration(RegistrationType::InitialRegistration);

--- a/nextgsim-ue/src/rrc/cell_selection.rs
+++ b/nextgsim-ue/src/rrc/cell_selection.rs
@@ -851,6 +851,10 @@ pub struct PlmnSelector {
     operator_preferred: Vec<Plmn>,
     /// Forbidden PLMN list (TS 23.122 Section 3.1)
     forbidden: Vec<Plmn>,
+    /// PLMNs currently available on the radio, reported by the RRC
+    /// CellSelector; the candidate set for automatic selection (TS 23.122
+    /// §4.4.3).
+    available: Vec<Plmn>,
     /// Manually chosen PLMN (manual mode)
     manual_selection: Option<Plmn>,
     /// Higher-priority PLMN search interval (timer T) in seconds
@@ -872,6 +876,7 @@ impl PlmnSelector {
             user_preferred: Vec::new(),
             operator_preferred: Vec::new(),
             forbidden: Vec::new(),
+            available: Vec::new(),
             manual_selection: None,
             hp_search_interval_secs: DEFAULT_HP_PLMN_SEARCH_INTERVAL_SECS,
             hp_search_elapsed_secs: 0,
@@ -933,6 +938,17 @@ impl PlmnSelector {
     /// BCD-encoded list converted via [`plmn_from_bcd`])
     pub fn set_forbidden(&mut self, plmns: Vec<Plmn>) {
         self.forbidden = plmns;
+    }
+
+    /// Sets the PLMNs currently available on the radio (TS 23.122 §4.4.3),
+    /// reported by the RRC CellSelector; the candidate set for [`Self::select`].
+    pub fn set_available_plmns(&mut self, plmns: Vec<Plmn>) {
+        self.available = plmns;
+    }
+
+    /// The PLMNs currently reported as available on the radio.
+    pub fn available_plmns(&self) -> &[Plmn] {
+        &self.available
     }
 
     /// Add a PLMN to the forbidden list

--- a/nextgsim-ue/src/rrc/task.rs
+++ b/nextgsim-ue/src/rrc/task.rs
@@ -381,6 +381,10 @@ impl RrcTask {
                     .nas_tx
                     .send(NasMessage::ActiveCellChanged {
                         previous_tai: old_tai,
+                        // Report the PLMNs the UE can currently see so NAS can
+                        // run TS 23.122 §4.4.3 selection over the real radio
+                        // rather than a hardcoded home-PLMN list.
+                        available_plmns: self.cell_selector.available_plmns(),
                     })
                     .await
                 {
@@ -1856,6 +1860,36 @@ mod tests {
         let (ch, _setup_req) = next_uplink_rrc(rls_rx);
         assert_eq!(ch, RrcChannel::UlCcch, "RRCSetupRequest must go on UL-CCCH");
         nas
+    }
+
+    /// On camping, the RRC task reports the radio's available PLMNs to NAS in
+    /// ActiveCellChanged (issue #49, TS 23.122 §4.4.3) — the production caller
+    /// of CellSelector::available_plmns — so NAS selects over the real radio
+    /// rather than a hardcoded home-PLMN list.
+    #[test]
+    fn test_active_cell_changed_reports_available_plmns() {
+        let (task_base, _app_rx, mut nas_rx, _rrc_rx, _rls_rx) = UeTaskBase::new(test_config(), 32);
+        let mut task = RrcTask::new(task_base);
+
+        run_async(async {
+            task.handle_signal_changed(1, -60).await;
+            task.perform_cycle().await; // camps on cell 1 → emits ActiveCellChanged
+
+            let mut reported: Option<Vec<CellPlmn>> = None;
+            while let Ok(msg) = nas_rx.try_recv() {
+                if let TaskMessage::Message(NasMessage::ActiveCellChanged {
+                    available_plmns, ..
+                }) = msg
+                {
+                    reported = Some(available_plmns);
+                }
+            }
+            let reported = reported.expect("ActiveCellChanged emitted on camp");
+            assert!(
+                !reported.is_empty(),
+                "available PLMNs reported to NAS for selection (TS 23.122 §4.4.3)"
+            );
+        });
     }
 
     /// T300 establishment guard (issue #30, TS 38.331 §5.3.3.2 / §5.3.3.4):

--- a/nextgsim-ue/src/tasks.rs
+++ b/nextgsim-ue/src/tasks.rs
@@ -353,6 +353,10 @@ pub enum NasMessage {
     ActiveCellChanged {
         /// Previous TAI
         previous_tai: Tai,
+        /// PLMNs currently available on the radio (broadcast by the cells the
+        /// UE can detect), reported by the RRC CellSelector for TS 23.122
+        /// §4.4.3 automatic PLMN selection. Empty if none are known yet.
+        available_plmns: Vec<crate::rrc::cell_selection::Plmn>,
     },
     /// RRC fallback indication (from RRC)
     RrcFallbackIndication,


### PR DESCRIPTION
## Summary

Automatic PLMN selection previously ran against a **hardcoded** one-element candidate list (`let available = [home_plmn]`), so the selector could never consider the PLMNs actually broadcast on the radio (TS 23.122 §4.4.3) — the `PlmnSelector` / `available_plmns()` machinery was a disconnected facade. Now that **#76** has the binary running the `CellSelector`-bearing library `RrcTask`, this wires its available-PLMN view into NAS selection. Addresses issue #49 **criteria 1 & 2**.

## Changes

- **`NasMessage::ActiveCellChanged`** carries `available_plmns`, populated by the RRC `perform_cell_selection` from `CellSelector::available_plmns()` — giving that method its **first production caller** (criterion 2).
- **`PlmnSelector`** gains an `available` field + `set_available_plmns` / `available_plmns`; the NAS loop refreshes it from each `ActiveCellChanged` report (an empty report leaves the last-known set in place).
- **`perform_plmn_selection`** builds its candidate list from the selector's reported available PLMNs (falling back to the home PLMN when none reported yet), replacing the hardcoded list (criterion 1) — so both the periodic higher-priority search and forbidden-PLMN reselection now select over the real radio.

## Backward compatibility

In the current single-PLMN sim the report is the home PLMN, so selection resolves exactly as before. Test added: the RRC task reports a non-empty available-PLMN list to NAS on camping.

## Deferred #49 follow-ups

- Record the **real serving-cell RPLMN** (criterion 3) — the recording site is inside `process_mm_outputs`, which has no serving-cell context, so it needs threading through that hub.
- **`UeConfig`** user/operator-preferred PLMN lists + higher-priority-search timer T (criterion 5).
- **NAS→RRC `set_selected_plmn`** push-back (criterion 4).
- The forbidden-PLMN reselection + periodic-search **acceptance tests** (criteria 6, 7).

Related #49

Signed-off-by: Murat Parlakisik <parlakisik@gmail.com>
