### PR TITLE
fix(nkef): build the TF-IDF vocabulary on insert so vector search actually runs

### DIFF
--- a/nextgsim-nkef/src/lib.rs
+++ b/nextgsim-nkef/src/lib.rs
@@ -295,6 +295,17 @@ impl Default for KnowledgeGraph {
 }
 
 impl KnowledgeGraph {
+    /// Minimum mapped relevance for a vector-search hit to be returned.
+    ///
+    /// Relevance is cosine similarity mapped from `[-1, 1]` to `[0, 1]`, so
+    /// 0.5 is "orthogonal / unrelated". The floor sits above that: TF-IDF
+    /// vectors over short entity documents are rarely truly orthogonal, so
+    /// without a cutoff every query matches the whole corpus.
+    ///
+    /// Deliberately conservative. Raising it trades recall for precision and
+    /// should be driven by a corpus large enough to measure the effect.
+    pub const MIN_VECTOR_RELEVANCE: f32 = 0.6;
+
     /// Creates a new knowledge graph with default embedding dimension (128).
     pub fn new() -> Self {
         Self::with_embedding_dim(128)
@@ -319,6 +330,13 @@ impl KnowledgeGraph {
     /// If an entity with the same ID already exists, it is replaced and the
     /// change is recorded in the entity history. An `EntityCreated` or
     /// `EntityUpdated` event is dispatched.
+    ///
+    /// Unless the entity arrives with an embedding already attached, this
+    /// refreshes the TF-IDF vocabulary and re-embeds the whole corpus, because
+    /// IDF is corpus-global. That is O(corpus) per insert, which suits the
+    /// incremental one-entity-per-message pattern the gNB NKEF task uses. For a
+    /// bulk load, prefer attaching embeddings yourself or inserting via a path
+    /// that defers to a single [`Self::rebuild_embeddings`] at the end.
     pub fn add_entity(&mut self, entity: Entity) {
         let id = entity.id.clone();
         let entity_type = entity.entity_type;
@@ -370,28 +388,29 @@ impl KnowledgeGraph {
                 .dispatch(KnowledgeEvent::entity_created(&id, now));
         }
 
-        // Generate embedding if not already present
-        let entity = if entity.embedding.is_some() {
-            entity
-        } else {
-            let text = TextEmbedder::entity_text(
-                &entity.id,
-                &format!("{:?}", entity.entity_type),
-                &entity.properties,
-            );
-            let emb = self.embedder.embed(&text);
-            Entity {
-                embedding: Some(emb),
-                ..entity
+        let caller_supplied_embedding = entity.embedding.clone();
+        self.entities.insert(id.clone(), entity);
+
+        match caller_supplied_embedding {
+            // The caller brought its own vector (e.g. a real neural embedder):
+            // index it verbatim and leave the TF-IDF corpus alone.
+            Some(emb) => {
+                self.vector_index.upsert(&id, emb);
             }
-        };
-
-        // Update vector index
-        if let Some(ref emb) = entity.embedding {
-            self.vector_index.upsert(&id, emb.clone());
+            // Otherwise derive one. TF-IDF is corpus-global -- adding a document
+            // changes every term's IDF -- so the vocabulary and all existing
+            // embeddings are refreshed rather than embedding this entity against
+            // a stale (or, on the first insert, EMPTY) vocabulary.
+            //
+            // Embedding against an empty vocabulary is what made the vector path
+            // dead in practice: TextEmbedder::embed returns an all-zero vector
+            // when the vocabulary is empty, so every entity was indexed as
+            // zeros. search() then passed its non-empty-index guard but found no
+            // non-zero query component and silently fell through to
+            // keyword_search forever. The gNB NKEF task only ever calls
+            // add_entity, so that was the only behaviour it could get.
+            None => self.rebuild_embeddings(),
         }
-
-        self.entities.insert(id, entity);
     }
 
     /// Gets an entity by ID
@@ -543,21 +562,31 @@ impl KnowledgeGraph {
             if has_nonzero {
                 let sim_results = self.vector_index.search_topk(&query_embedding, max_results);
 
-                if !sim_results.is_empty() {
-                    return sim_results
-                        .into_iter()
-                        .filter_map(|sr| {
-                            self.entities.get(&sr.id).map(|entity| {
-                                // Map cosine similarity [-1, 1] to relevance [0, 1]
-                                let relevance = (sr.score + 1.0) / 2.0;
-                                QueryResult {
-                                    entity: entity.clone(),
-                                    relevance,
-                                }
-                            })
+                // Cosine similarity ranks every indexed entity, so without a
+                // floor a query matches the entire corpus -- "Building A"
+                // returned all three entities in a three-entity graph, merely
+                // ordered correctly. Drop results below the cutoff so a search
+                // is a search and not a sorted dump.
+                let hits: Vec<QueryResult> = sim_results
+                    .into_iter()
+                    .filter_map(|sr| {
+                        // Map cosine similarity [-1, 1] to relevance [0, 1]
+                        let relevance = (sr.score + 1.0) / 2.0;
+                        if relevance < Self::MIN_VECTOR_RELEVANCE {
+                            return None;
+                        }
+                        self.entities.get(&sr.id).map(|entity| QueryResult {
+                            entity: entity.clone(),
+                            relevance,
                         })
-                        .collect();
+                    })
+                    .collect();
+
+                if !hits.is_empty() {
+                    return hits;
                 }
+                // Everything scored below the floor: fall through to keyword
+                // matching rather than returning nothing.
             }
         }
 
@@ -664,10 +693,15 @@ impl KnowledgeGraph {
 
     /// Rebuilds the TF-IDF vocabulary and all entity embeddings.
     ///
-    /// Call this after bulk-loading entities to ensure the vocabulary and
-    /// embeddings reflect the full corpus. Entities added via `add_entity`
-    /// get embeddings automatically, but the TF-IDF vocabulary is more
-    /// accurate when built from the full set of documents.
+    /// [`Self::add_entity`] now calls this for you whenever it has to derive an
+    /// embedding, so an explicit call is only needed after mutating entity
+    /// properties in place, or to re-embed a corpus loaded with
+    /// caller-supplied vectors.
+    ///
+    /// (The previous doc comment claimed entities added via `add_entity` "get
+    /// embeddings automatically" while the vocabulary merely became "more
+    /// accurate" after a rebuild. That understated it: without a rebuild the
+    /// vocabulary was empty, so those automatic embeddings were all zeros.)
     pub fn rebuild_embeddings(&mut self) {
         // Build corpus from all entities
         let documents: Vec<String> = self
@@ -1082,6 +1116,52 @@ mod tests {
 
         assert_eq!(graph.vector_index().len(), 2);
         assert!(graph.embedder().vocab_size() > 0);
+    }
+
+    #[test]
+    fn test_add_entity_alone_produces_usable_embeddings() {
+        // Regression: every other vector-search test in this file calls
+        // rebuild_embeddings() first, so none of them covered the path the gNB
+        // NKEF task actually takes -- add_entity, then search, and nothing else.
+        //
+        // On that path the vocabulary stayed empty, so TextEmbedder::embed
+        // returned an all-zero vector for every entity. add_entity then upserted
+        // those zeros, leaving a NON-EMPTY index full of useless vectors:
+        // search() passed its `!vector_index.is_empty()` guard, found
+        // `has_nonzero == false` for the query, and silently fell through to
+        // keyword_search on every call.
+        let mut graph = KnowledgeGraph::with_embedding_dim(64);
+
+        graph.add_entity(
+            Entity::new("gnb-001", EntityType::Gnb)
+                .with_property("name", "Alpha base station")
+                .with_property("status", "active"),
+        );
+        graph.add_entity(
+            Entity::new("ue-001", EntityType::Ue).with_property("name", "Mobile User Equipment"),
+        );
+
+        // No rebuild_embeddings() call: this is the production sequence.
+        assert!(
+            graph.embedder().vocab_size() > 0,
+            "add_entity must leave a usable TF-IDF vocabulary, not an empty one"
+        );
+
+        for id in ["gnb-001", "ue-001"] {
+            let entity = graph.get_entity(id).expect("entity must exist");
+            let emb = entity
+                .embedding
+                .as_ref()
+                .expect("add_entity must store an embedding");
+            assert!(
+                emb.iter().any(|&v| v != 0.0),
+                "{id} embedding must not be all zeros"
+            );
+        }
+
+        // And the vector path must actually be reached, not bypassed.
+        let results = graph.search("base station", 10);
+        assert!(!results.is_empty(), "search must return results");
     }
 
     #[test]

--- a/tests/src/ai_integration.rs
+++ b/tests/src/ai_integration.rs
@@ -491,14 +491,37 @@ fn test_nkef_knowledge_graph_e2e() {
             .with_property("connected_gnb", "gnb-001"),
     );
 
-    // Search for gNBs - note: search also finds UE's "connected_gnb" property containing "gnb"
+    // `search` now runs real TF-IDF cosine similarity rather than substring
+    // keyword matching, because add_entity maintains the vocabulary. So these
+    // assert RANKING, not exact counts: cosine similarity scores every entity
+    // and the graph is tiny, so several near-identical documents legitimately
+    // clear the relevance floor. Asserting a count here would pin an artefact
+    // of corpus size rather than search behaviour.
+    //
+    // "gnb" matches both gNBs and, weakly, the UE whose connected_gnb property
+    // references one -- that last hit is a property VALUE match, which is
+    // correct; the previous keyword implementation matched the property NAME.
     let results = graph.search("gnb", 10);
-    assert_eq!(results.len(), 3); // 2 gNBs + 1 UE with connected_gnb property
+    assert!(!results.is_empty());
+    assert!(
+        results[0].entity.id.starts_with("gnb-"),
+        "a gNB must outrank the UE for the query 'gnb', got {:?}",
+        results[0].entity.id
+    );
+    assert!(
+        results.windows(2).all(|w| w[0].relevance >= w[1].relevance),
+        "results must be ordered by descending relevance"
+    );
 
-    // Search for specific building
+    // Search for a specific building: gnb-001 is the one in Building A, so it
+    // must rank first. gnb-002's document differs by a single token, so it
+    // scoring nearby is expected, not a defect.
     let building_a = graph.search("Building A", 10);
-    assert_eq!(building_a.len(), 1);
-    assert_eq!(building_a[0].entity.id, "gnb-001");
+    assert!(!building_a.is_empty());
+    assert_eq!(
+        building_a[0].entity.id, "gnb-001",
+        "the entity actually in Building A must rank first"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`KnowledgeGraph::search` always fell through to keyword matching on the gNB path — but **not for the reason recorded in #29**.

The embedder and the index were both fine, and `add_entity` *did* upsert into the vector index. The actual cause: `TextEmbedder::embed` returns an **all-zero vector when the vocabulary is empty** (`embedder.rs:115`), and the vocabulary was only ever built by `build_vocabulary`, whose sole production caller was `rebuild_embeddings` — which nothing outside tests invoked.

So on the gNB path every entity was indexed as zeros. `search()` then:

1. passed its `!vector_index.is_empty()` guard (the index *was* populated — with zeros),
2. computed `has_nonzero == false` for the query embedding,
3. silently fell through to `keyword_search`. Every call, forever.

A non-empty index full of useless vectors is exactly why the guard never caught it.

The gNB NKEF task only ever calls `add_entity` (`nkef/task.rs:53`) then `search` (`:71`), so that was the only behaviour it could get. **Every existing vector-search test called `rebuild_embeddings()` explicitly first**, so none covered the production sequence.

## Changes

**1. `add_entity` maintains the vocabulary.** It refreshes the vocabulary and re-embeds the corpus whenever it derives an embedding. TF-IDF is corpus-global — a new document changes every term's IDF — so embedding against a stale vocabulary would be wrong in the same direction, just less obviously. An entity arriving *with* an embedding is indexed verbatim and leaves the corpus alone, so a real neural embedder still works.

**2. Added a relevance floor.** Enabling vector search exposed a second problem: cosine similarity ranks *every* indexed entity, so `search("Building A")` matched all three entities in a three-entity graph, merely ordered correctly. Hits below `MIN_VECTOR_RELEVANCE` (0.6 mapped — above the 0.5 "orthogonal" point) are dropped, and a query where everything scores below the floor falls through to keyword matching rather than returning nothing.

### Cost

`add_entity` is now O(corpus) per insert. That suits the incremental one-entity-per-message pattern the gNB uses; the doc comment says so and points bulk loaders at the alternatives.

## Test changes

`test_nkef_knowledge_graph_e2e` asserted exact result counts that only held under substring keyword matching — 3 hits for `"gnb"`, including a UE matched on a property **name**. It now asserts **ranking**: a gNB outranks the UE, results are ordered by descending relevance, and the entity actually in Building A ranks first. Counts there would pin corpus size, not search behaviour.

Also corrected `rebuild_embeddings`' doc comment, which claimed entities added via `add_entity` *"get embeddings automatically"* and that a rebuild merely made the vocabulary *"more accurate"*. Without a rebuild those automatic embeddings were all zeros.

## Verification

`test_add_entity_alone_produces_usable_embeddings` covers the production sequence with no `rebuild_embeddings()` call. Confirmed to fail against the old behaviour.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets` — zero errors, no new warnings (workspace holds at its 30-warning pre-existing baseline)
- `cargo test --workspace` — **3302 passed / 0 failed**

## Note for review

Two judgement calls worth a look:

- **`MIN_VECTOR_RELEVANCE = 0.6`** is deliberately conservative. Raising it trades recall for precision and should be driven by a corpus large enough to measure, not by a three-entity test.
- **The per-insert rebuild** is the simple correct choice, not the fast one. If NKEF ever grows a bulk-load path this should become an explicit deferred rebuild.

Relates to #29 — worth updating that issue, since its stated cause ("keyword matching" / embedder is a mock) is wrong: the TF-IDF embedder is real, it was just never given a vocabulary.