### PR TITLE
fix(gnb): stop feeding NWDAF a fabricated 0 dBm radio measurement

### DIFF
--- a/nextgsim-gnb/src/isac/task.rs
+++ b/nextgsim-gnb/src/isac/task.rs
@@ -103,12 +103,20 @@ impl Task for IsacTask {
                                     fused.position.z,
                                     fused.confidence
                                 );
-                                // Forward fused position to NWDAF for analytics
+                                // Forward the fused position to NWDAF for analytics.
+                                //
+                                // Position only: ISAC fuses ranging measurements
+                                // and has no serving-cell RSRP/RSRQ. This used to
+                                // send 0.0 for both, which the NWDAF anomaly
+                                // detector then treated as a real reading -- a
+                                // constant 0 dBm series, which is both physically
+                                // implausible and perfectly stable, so the z-score
+                                // detector could never flag anything.
                                 if let Some(ref sixg) = self.task_base.sixg {
                                     let nwdaf_msg = NwdafMessage::UeMeasurement {
                                         ue_id,
-                                        rsrp: 0.0,
-                                        rsrq: 0.0,
+                                        rsrp: None,
+                                        rsrq: None,
                                         position: (
                                             fused.position.x as f32,
                                             fused.position.y as f32,

--- a/nextgsim-gnb/src/nwdaf/task.rs
+++ b/nextgsim-gnb/src/nwdaf/task.rs
@@ -27,6 +27,14 @@ use nextgsim_nwdaf::{CellLoad, NwdafManager, NwdafResponse, UeMeasurement, Vecto
 
 use crate::tasks::{GnbTaskBase, NwdafMessage, RrcMessage, Task, TaskMessage};
 
+/// Nominal reference ceiling used to express PRB usage in Mbps-shaped units.
+///
+/// This is a placeholder, not a capacity model. The gNB config carries no cell
+/// bandwidth or numerology, so a real capacity cannot be derived here; a proper
+/// figure needs either a per-cell throughput counter on the data path or a
+/// bandwidth field to compute from.
+const NOMINAL_CELL_CAPACITY_MBPS: f32 = 1000.0;
+
 /// NWDAF Task for gNB
 ///
 /// Provides four-layer network data analytics with closed-loop automation.
@@ -59,14 +67,30 @@ impl NwdafTask {
         }
     }
 
-    /// Handles a UE measurement report
+    /// Handles a UE measurement report.
+    ///
+    /// A report without RSRP/RSRQ is **not** recorded as a measurement. The
+    /// analytics layer's `UeMeasurement` requires both as `f32`, so recording a
+    /// position-only report means inventing values, and there is no safe filler:
+    /// 0.0 reads as an implausibly strong signal, and any "typical" constant
+    /// makes the series artificially stable so the z-score anomaly detector can
+    /// never fire. Such reports are logged and dropped instead.
     fn handle_ue_measurement(
         &mut self,
         ue_id: i32,
-        rsrp: f32,
-        rsrq: f32,
+        rsrp: Option<f32>,
+        rsrq: Option<f32>,
         position: (f32, f32, f32),
     ) {
+        let (Some(rsrp), Some(rsrq)) = (rsrp, rsrq) else {
+            debug!(
+                "NWDAF: UE {ue_id} report carries no RSRP/RSRQ (pos=({}, {}, {})); \
+                 not recording a radio measurement",
+                position.0, position.1, position.2
+            );
+            return;
+        };
+
         debug!(
             "NWDAF: UE {} measurement - RSRP={} dBm, RSRQ={} dB, pos=({}, {}, {})",
             ue_id, rsrp, rsrq, position.0, position.1, position.2
@@ -112,7 +136,17 @@ impl NwdafTask {
             cell_id,
             prb_usage,
             connected_ues,
-            avg_throughput_mbps: prb_usage * 1000.0,
+            // NOT a measurement. The gNB keeps no per-cell throughput counter,
+            // and its config carries no cell bandwidth or numerology from which
+            // a capacity could be derived, so there is nothing to compute this
+            // from. It is PRB usage scaled by a nominal 1 Gbps reference
+            // ceiling: a restatement of prb_usage in Mbps-shaped units, not an
+            // independent signal.
+            //
+            // Kept rather than zeroed because the field is not Option and a 0
+            // would read as an idle cell. Any analytics treating this as
+            // observed throughput is reading prb_usage twice.
+            avg_throughput_mbps: prb_usage * NOMINAL_CELL_CAPACITY_MBPS,
             timestamp_ms: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_millis() as u64)
@@ -290,12 +324,50 @@ mod tests {
         let mut task = NwdafTask::new(task_base);
 
         // Record measurement
-        task.handle_ue_measurement(1, -80.0, -10.0, (100.0, 200.0, 0.0));
+        task.handle_ue_measurement(1, Some(-80.0), Some(-10.0), (100.0, 200.0, 0.0));
 
         // Verify measurement was recorded
         let history = task.nwdaf.get_ue_history(1);
         assert!(history.is_some());
         assert_eq!(history.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_position_only_report_is_not_recorded_as_a_measurement() {
+        // Regression: the ISAC task is the only live producer of UeMeasurement
+        // and it has no serving-cell RSRP/RSRQ. It used to send 0.0 for both,
+        // so the analytics layer recorded a constant 0 dBm series -- physically
+        // implausible AND perfectly stable, meaning the z-score anomaly detector
+        // could never fire while appearing to have real data to work on.
+        //
+        // A report with no radio measurement must not become a measurement.
+        let config = test_config();
+        let (task_base, _app_rx, _ngap_rx, _rrc_rx, _gtp_rx, _rls_rx, _sctp_rx) =
+            GnbTaskBase::new(config, DEFAULT_CHANNEL_CAPACITY);
+
+        let mut task = NwdafTask::new(task_base);
+
+        // Position-only, exactly what ISAC forwards.
+        task.handle_ue_measurement(7, None, None, (10.0, 20.0, 0.0));
+        assert!(
+            task.nwdaf.get_ue_history(7).is_none(),
+            "a report without RSRP/RSRQ must not be recorded as a measurement"
+        );
+
+        // A partial report is equally unusable.
+        task.handle_ue_measurement(7, Some(-80.0), None, (10.0, 20.0, 0.0));
+        assert!(
+            task.nwdaf.get_ue_history(7).is_none(),
+            "a report missing RSRQ must not be recorded either"
+        );
+
+        // A complete report still is.
+        task.handle_ue_measurement(7, Some(-80.0), Some(-10.0), (10.0, 20.0, 0.0));
+        assert_eq!(
+            task.nwdaf.get_ue_history(7).map(|h| h.len()),
+            Some(1),
+            "a complete report must be recorded"
+        );
     }
 
     #[tokio::test]
@@ -327,7 +399,12 @@ mod tests {
 
         // Record measurements to build history
         for i in 0..10 {
-            task.handle_ue_measurement(1, -80.0, -10.0, (i as f32 * 10.0, i as f32 * 5.0, 0.0));
+            task.handle_ue_measurement(
+                1,
+                Some(-80.0),
+                Some(-10.0),
+                (i as f32 * 10.0, i as f32 * 5.0, 0.0),
+            );
         }
 
         // Request prediction

--- a/nextgsim-gnb/src/tasks.rs
+++ b/nextgsim-gnb/src/tasks.rs
@@ -767,10 +767,18 @@ pub enum NwdafMessage {
     UeMeasurement {
         /// UE identifier
         ue_id: i32,
-        /// Serving cell RSRP (dBm)
-        rsrp: f32,
-        /// Serving cell RSRQ (dB)
-        rsrq: f32,
+        /// Serving cell RSRP (dBm), or `None` when the sender has no radio
+        /// measurement to report.
+        ///
+        /// Optional rather than defaulting to 0.0: the only producer on the
+        /// live path is the ISAC task, which derives a fused *position* and has
+        /// no access to RSRP. It used to send 0.0, and 0 dBm is not a neutral
+        /// placeholder -- it is an implausibly strong signal that the
+        /// downstream z-score anomaly detector happily consumed as real data.
+        /// `None` cannot be mistaken for a measurement.
+        rsrp: Option<f32>,
+        /// Serving cell RSRQ (dB), or `None` when unavailable. See `rsrp`.
+        rsrq: Option<f32>,
         /// Position (x, y, z in meters)
         position: (f32, f32, f32),
     },

--- a/tests/src/sixg_task_integration.rs
+++ b/tests/src/sixg_task_integration.rs
@@ -433,8 +433,8 @@ async fn test_nwdaf_to_rrc_handover_recommendation_arrives() {
         sixg.nwdaf_tx
             .send(NwdafMessage::UeMeasurement {
                 ue_id: 1,
-                rsrp: -80.0 - (i as f32) * 5.0,
-                rsrq: -10.0 - (i as f32) * 1.0,
+                rsrp: Some(-80.0 - (i as f32) * 5.0),
+                rsrq: Some(-10.0 - (i as f32) * 1.0),
                 position: (i as f32 * 10.0, 0.0, 0.0),
             })
             .await
@@ -514,8 +514,8 @@ async fn test_nwdaf_task_predict_trajectory_via_channel() {
         sixg.nwdaf_tx
             .send(NwdafMessage::UeMeasurement {
                 ue_id: 5,
-                rsrp: -75.0 - (i as f32),
-                rsrq: -9.0 - (i as f32) * 0.5,
+                rsrp: Some(-75.0 - (i as f32)),
+                rsrq: Some(-9.0 - (i as f32) * 0.5),
                 position: (i as f32 * 5.0, i as f32 * 3.0, 0.0),
             })
             .await


### PR DESCRIPTION
## Problem

The ISAC task is the only live producer of `NwdafMessage::UeMeasurement`, and it sent **`rsrp: 0.0, rsrq: 0.0`** (`isac/task.rs:110-111`). It fuses ranging measurements into a *position* and has no serving-cell measurement to report.

**0 dBm is not a neutral placeholder.** It is an implausibly strong signal, and the series was also *perfectly constant* — so the downstream z-score anomaly detector could never flag anything while appearing to have real data to work on. Worse than no input, because it looked like input.

## There is no real measurement to substitute

I checked the alternatives before deciding:

- **`parse_measurement_report`** (`rrc/handover.rs:1102`) *does* decode genuine serving and neighbour RSRP from RRC MeasurementReport PDUs — but it has **no production caller**, only its own test and a re-export. Measurement reports never reach the handover manager either.
- **The RLS layer** carries a real `dbm` from the channel model, but only UE-side. The gNB never sees it (zero occurrences of `dbm` under `nextgsim-gnb/`).

## Approach

Rather than invent a plausible number, make the type unable to express a fake one.

`rsrp` and `rsrq` are now `Option<f32>`, matching the `sinr: None` convention the analytics layer already uses for an unavailable measurement. ISAC sends `None`, and `handle_ue_measurement` **drops a report that lacks either value** instead of recording it. Its docstring states why there is no safe filler: `0.0` reads as a strong signal, and any "typical" constant makes the series artificially stable.

### Also annotated: `CellLoad.avg_throughput_mbps`

It was `prb_usage * 1000.0`, implying a fixed 1 Gbps ceiling for every cell regardless of bandwidth or numerology. That makes it a restatement of `prb_usage` in Mbps-shaped units, not an independent signal — **any analytics treating it as observed throughput is reading `prb_usage` twice.**

The magic number is now a named constant documenting that the gNB keeps no throughput counter and its config carries no bandwidth to compute one from. Left in place rather than zeroed, because the field is not `Option` and a `0` would read as an idle cell.

## Out of scope

`NwdafMessage::CellLoad` is still never constructed on the live path, so `handle_cell_load` remains reachable only from tests. Giving it a real producer needs a PRB accounting path that does not exist yet.

## Testing

`test_position_only_report_is_not_recorded_as_a_measurement` covers three cases: position-only (what ISAC actually sends), partial (RSRP but no RSRQ), and complete. Only the complete report is recorded.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy` — zero errors in **both** the default and `--features 6g` configurations (30 and 18 pre-existing warnings respectively)
- `cargo test --workspace` — **3305 passed / 0 failed**
- `cargo test --features nextgsim-gnb/6g` — **369 passed / 0 failed**

The second test run matters: this code is feature-gated out of a default build, so a default-only run would not have compiled the changed lines at all. Worth knowing for CI — `.github/workflows/ci.yml` runs `cargo test --workspace` with no `--features`, so nothing in CI currently type-checks the 6G tasks.

Relates to #18.