### PR TITLE
docs(nwdaf,nkef): drop two unsupportable 3GPP compliance claims

### DIFF
--- a/nextgsim-nkef/src/ontology.rs
+++ b/nextgsim-nkef/src/ontology.rs
@@ -162,7 +162,18 @@ impl Ontology {
         }
     }
 
-    /// Creates a 3GPP-compliant ontology with standard entity and relationship schemas
+    /// Creates an ontology seeded with 3GPP-flavoured entity and relationship
+    /// schemas: UE, gNB, AMF and Slice entities plus an `attached_to`
+    /// relationship.
+    ///
+    /// The naming follows 3GPP terminology, but this is **not** a compliant or
+    /// complete model of any 3GPP information model — it is four entity types
+    /// and one relationship, enough to exercise the knowledge graph. The
+    /// `3GPP-R18` version string labels the vocabulary the names are drawn from,
+    /// not a conformance level.
+    ///
+    /// The name is kept for API compatibility; prefer reading it as
+    /// "3GPP-shaped" rather than "3GPP-compliant".
     pub fn new_3gpp_compliant() -> Self {
         let mut ontology = Self::new("3GPP-R18");
 

--- a/nextgsim-nwdaf/Cargo.toml
+++ b/nextgsim-nwdaf/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-description = "Network Data Analytics Function (NWDAF) - 3GPP TS 23.288 compliant analytics for 6G networks"
+description = "Network Data Analytics Function (NWDAF) - analytics research prototype inspired by 3GPP TS 23.288; not a conformance implementation"
 
 [dependencies]
 tokio = { workspace = true }


### PR DESCRIPTION
## Problem

Two claims of 3GPP compliance the code does not support, both contradicting the project's own honesty convention for these crates.

### 1. `nextgsim-nwdaf` claimed compliance while its own docs denied it

`Cargo.toml` described the crate as *"3GPP TS 23.288 **compliant** analytics"*. Its own `lib.rs` already says the opposite, in detail:

> This crate is a **research prototype**. […] it implements no Nnwdaf SBI surface, no TS 29.500 ProblemDetails error model and no notification correlation IDs, and it is **not conformance-tested**.

So the manifest contradicted the crate documentation — and the manifest is what appears in `cargo metadata` and on a registry listing.

It was also the **only** one of the six 6G crates making that claim. The others are consistently careful:

| crate | description |
|---|---|
| isac | "research prototype inspired by the use cases in 3GPP TR 22.837 … not a conformance implementation" |
| she | "inspired by 3GPP TS 23.558 (not an implementation of the spec)" |
| fl | "research prototype; FL algorithms outside 3GPP scope" |
| **nwdaf** | ~~"3GPP TS 23.288 **compliant**"~~ |

Reworded to match its siblings.

### 2. `nkef`'s `new_3gpp_compliant()` builds four entity types

Documented as creating *"a 3GPP-compliant ontology with standard entity and relationship schemas"*. It defines **four entity types** (UE, gNB, AMF, Slice) and **one relationship** (`attached_to`) — 3GPP-flavoured naming, not a compliant or complete model of any 3GPP information model.

The doc comment now says what it actually builds, and notes that the `3GPP-R18` version string labels the vocabulary the names are drawn from, **not** a conformance level.

**The function name is left alone.** It is public API, and renaming it is a breaking change that buys nothing the doc comment does not already fix. The comment tells the reader to read it as "3GPP-shaped".

## Sweep

Checked the workspace for the same class of claim while here. `nkef` and `semantic` both already carry the disclaimer in their `lib.rs`, and no other "compliant" assertion remains.

## Gates

Documentation only, no behaviour change.

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets` — zero errors, no new warnings (30-warning baseline held)
- `cargo test --workspace` — **3305 passed / 0 failed**
- `cargo test -p nextgsim-gnb --features 6g` — **259 passed / 0 failed**