### PR TITLE
WIP: chore: add .dockerignore so target/ stays out of the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Rust build artifacts. build.sh uses this directory as the docker build
+# context for Dockerfile.gnb-local / Dockerfile.ue-local, which need only
+# binaries/ -- without this, target/ (~22GB) ships to the daemon.
+target/
+**/target/
+
+.git/


### PR DESCRIPTION
## Problem

`nextgcore/docker/rust/build.sh` builds the gNB and UE images with **this directory** as the docker build context (`Dockerfile.gnb-local` / `Dockerfile.ue-local`), and those Dockerfiles need only `binaries/`. Without a `.dockerignore` here, `target/` (~22GB) ships to the daemon on every image build.

Measured while building the Kind images — free disk went from **53GB to 27GB in about 90 seconds** as the context transferred:

```
#7 [internal] load build context
#7 transferring context: 15.64GB 90.9s
```

That is exactly the image-store-wipe-under-disk-pressure hazard `nextgcore`'s `preflight.sh` exists to prevent, and **preflight cannot catch it** — it checks free space *before* the transfer that consumes it. I killed the build before the store was damaged; space returned and no images were lost.

## Fix

Exclude `target/` and `.git/` only. The gNB/UE Dockerfiles copy from `binaries/`, so nothing else in the tree needs listing.

Verified the gNB image still builds with this in place.

## Note

The companion gap is in the other repo: `build.sh` uses the **nextg repo root** as its context for the Rust builder stage, and the only `.dockerignore` there lives in `nextgcore/`, which Docker never reads for a parent context. That one is tracked separately.