### PR TITLE
chore(ue): remove the unreachable PerformMmCycle initial-attach path

### DIFF
--- a/nextgsim-ue/src/main.rs
+++ b/nextgsim-ue/src/main.rs
@@ -759,20 +759,22 @@ impl UeApp {
                                 && orch.state().mm_substate()
                                     != nextgsim_ue::nas::mm::MmSubState::RegisteredInitiated
                             {
-                                // Initial registration on first camp. The library
-                                // RrcTask emits ActiveCellChanged when it camps on
-                                // a cell; issue #30 removed the inline loop that
-                                // previously sent PerformMmCycle here, so this is
-                                // now the initial-attach trigger. The mm_substate
-                                // guard makes it one-shot: while a registration is
-                                // in flight (5GMM-REGISTERED-INITIATED still reports
-                                // rm_state DEREGISTERED) a re-entrant
-                                // ActiveCellChanged from a mid-attach cell
-                                // reselection is dropped here rather than blocking
-                                // the NAS loop on the sleep below (restores the
-                                // deleted loop's registration_triggered latch).
-                                // Give the gNB a moment to finish NG Setup with the
-                                // AMF first (matches the prior PerformMmCycle path).
+                                // Initial registration on first camp, and the ONLY
+                                // initial-attach trigger: the library RrcTask emits
+                                // ActiveCellChanged when it camps on a cell, and
+                                // issue #30 removed the inline loop that used to
+                                // drive the attach from a NasMessage::PerformMmCycle
+                                // self-message (that variant and its handler were
+                                // subsequently deleted as unreachable — nothing ever
+                                // sent it again). The mm_substate guard makes this
+                                // one-shot: while a registration is in flight
+                                // (5GMM-REGISTERED-INITIATED still reports rm_state
+                                // DEREGISTERED) a re-entrant ActiveCellChanged from a
+                                // mid-attach cell reselection is dropped here rather
+                                // than blocking the NAS loop on the sleep below
+                                // (restores the deleted loop's registration_triggered
+                                // latch). Give the gNB a moment to finish NG Setup
+                                // with the AMF first.
                                 tokio::time::sleep(tokio::time::Duration::from_millis(1000))
                                     .await;
                                 let outs = orch.start_registration(
@@ -825,28 +827,6 @@ impl UeApp {
                                     orch.state().rm_state(),
                                     orch.state().cm_state()
                                 );
-                            }
-                        }
-                        NasMessage::PerformMmCycle => {
-                            info!("PerformMmCycle received, MM state: {}", orch.state());
-
-                            // If we're deregistered, start the initial registration
-                            if orch.state().is_deregistered() {
-                                // Wait a bit for gNB to complete NG Setup with AMF
-                                tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
-                                let outs = orch
-                                    .start_registration(RegistrationType::InitialRegistration);
-                                process_mm_outputs(
-                                    outs,
-                                    &mut orch,
-                                    &mut sm_orch,
-                                    &sm_session_params,
-                                    &mut plmn_selector,
-                                    &task_base,
-                                    &tun_tx,
-                                    &mut pdu_counter,
-                                )
-                                .await;
                             }
                         }
                         NasMessage::NasTimerExpire { timer_id } => {

--- a/nextgsim-ue/src/tasks.rs
+++ b/nextgsim-ue/src/tasks.rs
@@ -367,8 +367,6 @@ pub enum NasMessage {
         /// User data
         data: OctetString,
     },
-    /// Perform MM cycle (internal)
-    PerformMmCycle,
     /// NAS timer expired (internal)
     NasTimerExpire {
         /// Timer ID


### PR DESCRIPTION
## What

`nextgsim-ue` carried two initial-registration triggers and only one could ever run. Removes the dead one.

- **Live**: `NasMessage::ActiveCellChanged` (`main.rs:758`) starts `InitialRegistration` when the UE is deregistered and not already `RegisteredInitiated`.
- **Dead**: `NasMessage::PerformMmCycle` (`tasks.rs:371`, handler `main.rs:830-851`) — a near-identical block (same 1000 ms NG-Setup sleep, same `start_registration`, same `process_mm_outputs`) that **nothing ever sent**.

Issue #30 replaced the inline loop that used to send `PerformMmCycle` with the `ActiveCellChanged` trigger, but left the variant and its handler behind. A repo-wide grep finds only the declaration, the handler, and two past-tense comments — no sender in any crate, including `tests/`.

## Why it matters

Unreachable code cannot misbehave, so this is not a runtime fix. The cost was in reading the file: two competing attach paths with no way to tell which is authoritative without grepping for senders. The dead copy also **lacked the live path's `mm_substate` one-shot guard**, so anyone extending the wrong one would reintroduce the re-entrancy that guard exists to prevent.

The surviving comment now states that `ActiveCellChanged` is the only attach trigger and that `PerformMmCycle` was deleted as unreachable, so the history stays legible without implying the variant still exists.

## Compatibility

Removing a variant from the `pub NasMessage` enum is technically breaking. Safe here: `nextgsim-ue` is an unpublished workspace member, and the only external consumer — the in-tree `tests/` crate — matches on `NasDelivery`, never on `PerformMmCycle`.

## Verification

- `grep -rn PerformMmCycle --include='*.rs'` returns only the explanatory comment
- `cargo check --workspace` clean: no unreachable-pattern or unused-variant warnings
- `cargo test --workspace`: **3305 passed / 0 failed**
- `cargo fmt --check` clean; clippy shows 30 pre-existing warnings on `main`, none in these files

**No regression test accompanies this, deliberately**: the removed code could not execute, so there is no behaviour to pin and no revert check to run. The compiler is the evidence.

Spec: `specs/remove-dead-perform-mm-cycle.md`